### PR TITLE
perf(daemon): batch EC I/O, add combined IPC variants, fix battery LE…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Loose release binaries at repo root (used by install.sh)
+/lecoo-ec-daemon
+/lecoo-ctrl

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -144,7 +144,7 @@ enum CliLedAction {
     #[command(about = loc!("cmd_led_custom_about"))]
     Custom {
         #[arg(help = loc!("arg_led_val_help"))]
-        val: u8
+        val: u8,
     },
 }
 
@@ -207,8 +207,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Lazy connection with localized error context
-    let mut client = IpcClient::connect()
-        .with_context(|| loc!("err_daemon_connection"))?;
+    let mut client = IpcClient::connect().with_context(|| loc!("err_daemon_connection"))?;
 
     let request = match cli.command {
         Commands::Info => IpcRequest::GetSystemState,
@@ -219,12 +218,22 @@ fn main() -> anyhow::Result<()> {
             let update_rate = (rate.unwrap_or(1.0) * 1000.0) as u64;
             println!("{}", t!("msg_monitoring_start", rate = update_rate));
             loop {
-                let IpcResponse::Temp(cpu, system) = client.request(&IpcRequest::GetTemperatures)? else { unreachable!() };
-                let IpcResponse::FanRPM(cpu_fan, gpu_fan) = client.request(&IpcRequest::GetFansRPM)? else { unreachable!() };
+                let IpcResponse::Monitoring(cpu, system, cpu_fan, gpu_fan) =
+                    client.request(&IpcRequest::GetMonitoring)?
+                else {
+                    unreachable!()
+                };
 
-                print!("\r{}      ", t!("msg_monitoring_loop",
-                    cpu = cpu, sys = system, cpu_f = cpu_fan, gpu_f = gpu_fan
-                ));
+                print!(
+                    "\r{}      ",
+                    t!(
+                        "msg_monitoring_loop",
+                        cpu = cpu,
+                        sys = system,
+                        cpu_f = cpu_fan,
+                        gpu_f = gpu_fan
+                    )
+                );
                 io::stdout().flush().unwrap();
                 std::thread::sleep(std::time::Duration::from_millis(update_rate));
             }
@@ -240,7 +249,7 @@ fn main() -> anyhow::Result<()> {
                 };
                 IpcRequest::SetPowerProfile(power_p)
             }
-        }
+        },
 
         Commands::Fan { target, mode, val } => {
             let fan_m = match mode {
@@ -251,12 +260,12 @@ fn main() -> anyhow::Result<()> {
             let fan_idx = match target {
                 CliFanIndex::Cpu => FanIndex::Cpu,
                 CliFanIndex::Gpu => FanIndex::Gpu,
-                CliFanIndex::Both => {
-                    let _: IpcResponse = client.request(&IpcRequest::SetFanMode { fan: FanIndex::Cpu, mode: fan_m } )?;
-                    FanIndex::Gpu
-                },
+                CliFanIndex::Both => FanIndex::Both,
             };
-            IpcRequest::SetFanMode { fan: fan_idx, mode: fan_m }
+            IpcRequest::SetFanMode {
+                fan: fan_idx,
+                mode: fan_m,
+            }
         }
 
         Commands::Charge { limit } => match limit {
@@ -297,19 +306,25 @@ fn main() -> anyhow::Result<()> {
 
         Commands::Daemon { action } => match action {
             CliDaemonAction::Telemetry { telemetry_action } => match telemetry_action {
-                CliTelemetryAction::Enable => IpcRequest::DaemonCommand(DaemonCommand::ActivateTelemetry(true)),
-                CliTelemetryAction::Disable => IpcRequest::DaemonCommand(DaemonCommand::ActivateTelemetry(false)),
+                CliTelemetryAction::Enable => {
+                    IpcRequest::DaemonCommand(DaemonCommand::ActivateTelemetry(true))
+                }
+                CliTelemetryAction::Disable => {
+                    IpcRequest::DaemonCommand(DaemonCommand::ActivateTelemetry(false))
+                }
                 CliTelemetryAction::Id => IpcRequest::DaemonCommand(DaemonCommand::GetTelemetryId),
             },
             CliDaemonAction::Settings { settings_action } => match settings_action {
-                CliSettingsAction::Reset => IpcRequest::DaemonCommand(DaemonCommand::RestoreDefaults),
+                CliSettingsAction::Reset => {
+                    IpcRequest::DaemonCommand(DaemonCommand::RestoreDefaults)
+                }
                 CliSettingsAction::Read => IpcRequest::DaemonCommand(DaemonCommand::GetSettings),
                 CliSettingsAction::Apply => IpcRequest::DaemonCommand(DaemonCommand::ApplySettings),
             },
             CliDaemonAction::Version => {
                 println!("{}.{}", client.daemon_version.0, client.daemon_version.1);
                 std::process::exit(0);
-            },
+            }
         },
     };
 
@@ -319,7 +334,10 @@ fn main() -> anyhow::Result<()> {
         IpcResponse::Success => println!("{}", t!("msg_success")),
 
         IpcResponse::SystemInfo(chip, rev, offset, ver) => {
-            println!("{}", t!("resp_sys_info", chip = chip, rev = rev, offset = offset : {:04X}, ver = ver));
+            println!(
+                "{}",
+                t!("resp_sys_info", chip = chip, rev = rev, offset = offset : {:04X}, ver = ver)
+            );
         }
 
         IpcResponse::FanRPM(cpu, gpu) => {
@@ -328,6 +346,17 @@ fn main() -> anyhow::Result<()> {
 
         IpcResponse::Temp(cpu, sys) => {
             println!("{}", t!("resp_temps", cpu = cpu, sys = sys));
+        }
+
+        IpcResponse::Monitoring(_, _, _, _) => {
+            // The monitoring variant is only used inside the live-loop command,
+            // which never reaches this match (it handles the response inline).
+            // If somehow we get here, treat as an error.
+            eprintln!(
+                "{}",
+                t!("msg_error", msg = "Unexpected Monitoring response")
+            );
+            std::process::exit(1);
         }
 
         IpcResponse::KeyboardBacklight(lvl) => {
@@ -362,7 +391,7 @@ fn main() -> anyhow::Result<()> {
             DaemonResponse::Settings(s) => println!("{:#?}", s),
             DaemonResponse::TelemetryId(id) => {
                 println!("{}", t!("resp_telemetry_id", id = id : {:016X}));
-            },
+            }
         },
     }
 

--- a/daemon/src/ec/hw/fan.rs
+++ b/daemon/src/ec/hw/fan.rs
@@ -1,13 +1,11 @@
+use super::EcDevice;
 use anyhow::{Result, bail};
 use ipc::{FanIndex, FanMode};
-use super::EcDevice;
 
+/// Apply a fan mode to a specific fan index.
+/// When `fan` is `Both`, the same mode is applied to both CPU and GPU fans
+/// atomically (single lock cycle).
 pub fn apply_fan_mode(ec: &EcDevice, fan: &FanIndex, mode: &FanMode) -> Result<()> {
-    let thermal_policy_override: u16 = match fan {
-        FanIndex::Cpu => ec.offsets.ram_thermal_policy_cpu,
-        FanIndex::Gpu => ec.offsets.ram_thermal_policy_gpu,
-    };
-
     let (policy, duty) = match mode {
         FanMode::Auto => (0x00, 0),
         FanMode::Full => (0x40, 150),
@@ -19,8 +17,23 @@ pub fn apply_fan_mode(ec: &EcDevice, fan: &FanIndex, mode: &FanMode) -> Result<(
         }
     };
 
-    ec.with_batch(|b| {
-        b.write_ram(thermal_policy_override, policy)?;
-        b.write_ram(*fan as u16, duty)
-    })
+    match fan {
+        FanIndex::Both => ec.with_batch(|b| {
+            b.write_ram(b.offsets.ram_thermal_policy_cpu, policy)?;
+            b.write_ram(b.offsets.ram_thermal_policy_gpu, policy)?;
+            b.write_ram(FanIndex::Cpu as u16, duty)?;
+            b.write_ram(FanIndex::Gpu as u16, duty)
+        }),
+        FanIndex::Cpu | FanIndex::Gpu => {
+            let thermal_policy_override: u16 = match fan {
+                FanIndex::Cpu => ec.offsets.ram_thermal_policy_cpu,
+                FanIndex::Gpu => ec.offsets.ram_thermal_policy_gpu,
+                FanIndex::Both => unreachable!(),
+            };
+            ec.with_batch(|b| {
+                b.write_ram(thermal_policy_override, policy)?;
+                b.write_ram(*fan as u16, duty)
+            })
+        }
+    }
 }

--- a/daemon/src/ec/hw/flexicharger.rs
+++ b/daemon/src/ec/hw/flexicharger.rs
@@ -1,11 +1,13 @@
-use ipc::ChargeLimit;
-use anyhow::{Ok, Result};
 use super::EcDevice;
+use anyhow::{Ok, Result};
+use ipc::ChargeLimit;
 
 pub fn read_charge_limit(ec: &EcDevice) -> Result<(u8, u8)> {
-    let min = ec.read_ram(ec.offsets.ram_bat_limit_min)? as u8;
-    let max = ec.read_ram(ec.offsets.ram_bat_limit_max)? as u8;
-    Ok((min, max))
+    ec.with_batch(|b| {
+        let min = b.read_ram(b.offsets.ram_bat_limit_min)?;
+        let max = b.read_ram(b.offsets.ram_bat_limit_max)?;
+        Ok((min, max))
+    })
 }
 
 pub fn read_battery_rsoc(ec: &EcDevice) -> Result<u8> {

--- a/daemon/src/ec/hw/getters.rs
+++ b/daemon/src/ec/hw/getters.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
 use super::EcDevice;
+use anyhow::Result;
+use ipc::PowerProfile;
 
 pub fn read_system_info(ec: &EcDevice) -> Result<(u8, u8, u8)> {
     ec.with_batch(|b| {
@@ -26,8 +27,38 @@ pub fn read_fans_rpm(ec: &EcDevice) -> Result<(u16, u16)> {
 
 pub fn read_temperatures(ec: &EcDevice) -> Result<(u8, u8)> {
     ec.with_batch(|b| {
-        let cpu_temp = b.read_ram(b.offsets.ram_temp_cpu)? as u8;
-        let sys_temp = b.read_ram(b.offsets.ram_temp_sys)? as u8;
+        let cpu_temp = b.read_ram(b.offsets.ram_temp_cpu)?;
+        let sys_temp = b.read_ram(b.offsets.ram_temp_sys)?;
         Ok((cpu_temp, sys_temp))
+    })
+}
+
+/// Atomically read power profile + temps + fan RPMs in a single lock cycle.
+/// Used by the telemetry worker to minimize contention with IPC clients.
+pub fn read_status_snapshot(ec: &EcDevice) -> Result<(PowerProfile, u8, u8, u16, u16)> {
+    ec.with_batch(|b| {
+        let profile_raw = b.read_ram(b.offsets.ram_power_profile)?;
+        let cpu_temp = b.read_ram(b.offsets.ram_temp_cpu)?;
+        let sys_temp = b.read_ram(b.offsets.ram_temp_sys)?;
+
+        let cpu_msb = b.read_ram(b.offsets.ram_fan_cpu_msb)? as u16;
+        let cpu_lsb = b.read_ram(b.offsets.ram_fan_cpu_lsb)? as u16;
+        let gpu_msb = b.read_ram(b.offsets.ram_fan_gpu_msb)? as u16;
+        let gpu_lsb = b.read_ram(b.offsets.ram_fan_gpu_lsb)? as u16;
+
+        let profile = match profile_raw {
+            1 => PowerProfile::Silent,
+            2 => PowerProfile::Default,
+            3 => PowerProfile::Performance,
+            _ => PowerProfile::Default,
+        };
+
+        Ok((
+            profile,
+            cpu_temp,
+            sys_temp,
+            (cpu_msb << 8) | cpu_lsb,
+            (gpu_msb << 8) | gpu_lsb,
+        ))
     })
 }

--- a/daemon/src/ec/hw/kbd_backlight.rs
+++ b/daemon/src/ec/hw/kbd_backlight.rs
@@ -1,20 +1,22 @@
-use ipc::KeyboardBacklightLevel;
-use anyhow::Result;
 use super::EcDevice;
+use anyhow::Result;
+use ipc::KeyboardBacklightLevel;
 
 pub fn read_keyboard_backlight(ec: &EcDevice) -> Result<KeyboardBacklightLevel> {
-    match ec.read_reg(ec.offsets.reg_kbd_backlight)? {
+    ec.with_batch(|b| match b.read_reg(b.offsets.reg_kbd_backlight)? {
         0x00 => Ok(KeyboardBacklightLevel::Off),
         0x01 => Ok(KeyboardBacklightLevel::Low),
         0x02 => Ok(KeyboardBacklightLevel::Medium),
         0x03 => Ok(KeyboardBacklightLevel::High),
         0xFF => {
-            let custom_value = ec.read_reg(ec.offsets.reg_kbd_custom_val)?;
+            let custom_value = b.read_reg(b.offsets.reg_kbd_custom_val)?;
             Ok(KeyboardBacklightLevel::Custom(custom_value))
         }
-
-        v => Err(anyhow::anyhow!("Invalid keyboard backlight level: {:#04x}", v)),
-    }
+        v => Err(anyhow::anyhow!(
+            "Invalid keyboard backlight level: {:#04x}",
+            v
+        )),
+    })
 }
 
 pub fn apply_keyboard_backlight(ec: &EcDevice, level: &KeyboardBacklightLevel) -> Result<()> {

--- a/daemon/src/ec/hw/led.rs
+++ b/daemon/src/ec/hw/led.rs
@@ -1,16 +1,16 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use ipc::PowerLedMode;
-use anyhow::Result;
 use super::EcDevice;
+use anyhow::Result;
+use ipc::PowerLedMode;
 
 static IS_LED_ALREADY_CUSTOM: AtomicBool = AtomicBool::new(false);
 
 pub fn reset_led_anim_engine(ec: &EcDevice) -> Result<()> {
     ec.with_batch(|b| {
-        b.write_reg(b.offsets.reg_led_breath_en, 0x00)?;     // Disable hardware breathing dimmer
-        b.write_reg(b.offsets.reg_pwm_prescaler, 0x00)?;     // Reset prescaler (maximum PWM frequency)
-        b.write_reg(b.offsets.reg_pwm_cycle, 0xFF)           // Reset Cycle Time (standard 256 steps)
+        b.write_reg(b.offsets.reg_led_breath_en, 0x00)?; // Disable hardware breathing dimmer
+        b.write_reg(b.offsets.reg_pwm_prescaler, 0x00)?; // Reset prescaler (maximum PWM frequency)
+        b.write_reg(b.offsets.reg_pwm_cycle, 0xFF) // Reset Cycle Time (standard 256 steps)
     })
 }
 // TODO: improve logic here... one day
@@ -27,12 +27,12 @@ pub fn apply_led_mode(ec: &EcDevice, mode: &PowerLedMode) -> Result<()> {
         // Set LED to custom brightness value
         PowerLedMode::Custom(brightness) => {
             if !IS_LED_ALREADY_CUSTOM.load(Ordering::Relaxed) {
-                ec.write_ram(offsets.ram_led_bypass, 0x01)?;            // LED-controller bypass mode
-                ec.write_reg(offsets.reg_gpio_a0_mux, 0x00)?;           // Pin multiplexer in manual mode
+                ec.write_ram(offsets.ram_led_bypass, 0x01)?; // LED-controller bypass mode
+                ec.write_reg(offsets.reg_gpio_a0_mux, 0x00)?; // Pin multiplexer in manual mode
                 IS_LED_ALREADY_CUSTOM.store(true, Ordering::Relaxed);
             }
-            reset_led_anim_engine(ec)?;                 // TODO HERE! call only if it hasn't been called already
-            ec.write_reg(offsets.reg_pwm_duty, *brightness)?;           // PWM Duty Cycle Register (brightness)
+            reset_led_anim_engine(ec)?; // TODO HERE! call only if it hasn't been called already
+            ec.write_reg(offsets.reg_pwm_duty, *brightness)?; // PWM Duty Cycle Register (brightness)
         }
 
         // Set LED to breathing animation
@@ -51,14 +51,13 @@ pub fn apply_led_mode(ec: &EcDevice, mode: &PowerLedMode) -> Result<()> {
             // Assemble byte for the PWM0LCR1 register
             // Bits [5:4] - Max Brightness | Bits [3:2] - Step Down | Bits [1:0] - Step Up
             let lcr1_val = ((config.max_brightness as u8) << 4)
-                            | ((config.step_down as u8) << 2)
-                            | (config.step_up as u8);
+                | ((config.step_down as u8) << 2)
+                | (config.step_up as u8);
             ec.write_reg(offsets.reg_led_breath_step, lcr1_val)?;
 
             // Assemble byte for the PWM0LCR2 register
             // Bits [6:4] - Delay at Max | Bits [2:0] - Delay at Min
-            let lcr2_val = ((config.delay_at_max as u8) << 4)
-                            | (config.delay_at_min as u8);
+            let lcr2_val = ((config.delay_at_max as u8) << 4) | (config.delay_at_min as u8);
             ec.write_reg(offsets.reg_led_breath_delay, lcr2_val)?;
 
             // Aaaand launching the hardware breathing engine!
@@ -71,19 +70,21 @@ pub fn apply_led_mode(ec: &EcDevice, mode: &PowerLedMode) -> Result<()> {
 
 pub fn apply_battery_leds(ec: &EcDevice, orange_on: bool, white_on: bool) -> Result<()> {
     let offsets = ec.offsets;
-    let mut port_a = ec.read_reg(offsets.reg_gpdra)?;
+    ec.with_batch(|b| {
+        let mut port_a = b.read_reg(offsets.reg_gpdra)?;
 
-    if orange_on {
-        port_a &= !offsets.mask_orange_led; // On
-    } else {
-        port_a |= offsets.mask_orange_led;  // Off
-    }
+        if orange_on {
+            port_a &= !offsets.mask_orange_led; // On
+        } else {
+            port_a |= offsets.mask_orange_led; // Off
+        }
 
-    if white_on {
-        port_a &= !offsets.mask_white_led;  // On
-    } else {
-        port_a |= offsets.mask_white_led;   // Off
-    }
+        if white_on {
+            port_a &= !offsets.mask_white_led; // On
+        } else {
+            port_a |= offsets.mask_white_led; // Off
+        }
 
-    ec.write_reg(offsets.reg_gpdra, port_a)
+        b.write_reg(offsets.reg_gpdra, port_a)
+    })
 }

--- a/daemon/src/ec/hw/mod.rs
+++ b/daemon/src/ec/hw/mod.rs
@@ -1,15 +1,15 @@
 pub use super::EcDevice;
 
-mod getters;
-mod power_profile;
-mod kbd_backlight;
-mod led;
 mod fan;
 mod flexicharger;
+mod getters;
+mod kbd_backlight;
+mod led;
+mod power_profile;
 
-pub use power_profile::*;
+pub use fan::*;
+pub use flexicharger::*;
 pub use getters::*;
 pub use kbd_backlight::*;
 pub use led::*;
-pub use fan::*;
-pub use flexicharger::*;
+pub use power_profile::*;

--- a/daemon/src/ec/hw/power_profile.rs
+++ b/daemon/src/ec/hw/power_profile.rs
@@ -1,12 +1,9 @@
-use ipc::{IpcResponse, PowerProfile};
-use anyhow::{Result, bail};
 use super::EcDevice;
+use anyhow::{Result, bail};
+use ipc::{IpcResponse, PowerProfile};
 
 pub fn apply_power_profile(ec: &EcDevice, profile: &PowerProfile) -> Result<IpcResponse> {
-    ec.write_ram(
-        ec.offsets.ram_power_profile,
-        *profile as u8
-    )?;
+    ec.write_ram(ec.offsets.ram_power_profile, *profile as u8)?;
     Ok(IpcResponse::Success)
 }
 

--- a/daemon/src/ec/mod.rs
+++ b/daemon/src/ec/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::sync::Mutex;
 
 #[cfg(target_os = "linux")]
@@ -40,11 +40,9 @@ impl EcDevice {
         // Probe for motherboard type
         if motherboard.contains("N155A") {
             log::info!("Detected motherboard N155A.");
-        }
-        else if motherboard.contains("N155C") {
+        } else if motherboard.contains("N155C") {
             log::info!("Detected motherboard N155C.");
-        }
-        else if motherboard.contains("N155D") {
+        } else if motherboard.contains("N155D") {
             log::info!("Detected motherboard N155D.");
             offsets = EcOffsets::DEFAULT_N155D;
         } else if !insecure_mode {
@@ -57,7 +55,7 @@ impl EcDevice {
             io: Mutex::new(io),
             port: 0,
             offsets,
-            hram_offset: 0xFF
+            hram_offset: 0xFF,
         };
 
         device.probe_chip(insecure_mode)?;
@@ -65,12 +63,17 @@ impl EcDevice {
         let possible_bases: [u16; 5] = [0xC400, 0xC000, 0x0400, 0x0000, 0xE000];
         for &base in &possible_bases {
             // A REALLY(!) weak heuristic for detecting HRAM window
-            if let Ok(temp) = device.read_reg(base + device.offsets.ram_temp_cpu) {
-                if temp > 0x10 && temp < 0x50 {
-                    device.hram_offset = base;
-                    log::info!("HRAM Window detected by offset: {:#06X}. Temp: {}", base, temp);
-                    break;
-                }
+            if let Ok(temp) = device.read_reg(base + device.offsets.ram_temp_cpu)
+                && temp > 0x10
+                && temp < 0x50
+            {
+                device.hram_offset = base;
+                log::info!(
+                    "HRAM Window detected by offset: {:#06X}. Temp: {}",
+                    base,
+                    temp
+                );
+                break;
             }
         }
 
@@ -98,7 +101,11 @@ impl EcDevice {
                     return Ok(()); // Successfully found IT5570
                 }
                 if chip_id == 0x81 || chip_id == 0x85 || chip_id == 0x89 || chip_id == 0x90 {
-                    log::warn!("Warning: Found chip ID {:#X} at port {:#X}", chip_id, self.port);
+                    log::warn!(
+                        "Warning: Found chip ID {:#X} at port {:#X}",
+                        chip_id,
+                        self.port
+                    );
                     log::warn!("Note: This chip may not be fully supported");
                     return Ok(());
                 }
@@ -107,7 +114,9 @@ impl EcDevice {
 
         if insecure_mode {
             log::warn!("ITE chip not detected on any known port.");
-            log::warn!("INSECURE MODE: Proceeding blindly. Interacting with unknown hardware may cause system instability or damage!");
+            log::warn!(
+                "INSECURE MODE: Proceeding blindly. Interacting with unknown hardware may cause system instability or damage!"
+            );
             Ok(())
         } else {
             bail!("ITE IT5570/IT8987 chip not found on any known port")

--- a/daemon/src/ec/offsets.rs
+++ b/daemon/src/ec/offsets.rs
@@ -49,7 +49,6 @@ pub struct EcOffsets {
     pub reg_kbd_custom_val: u16,
 
     // == LED Controller (Port A0 / PWM Engine) ==
-
     /// Port A0 Control (Switches pin to manual PWM mode)
     pub reg_gpdra: u16,
     /// Switches pin A0 to manual PWM mode

--- a/daemon/src/ec/sys_linux.rs
+++ b/daemon/src/ec/sys_linux.rs
@@ -1,6 +1,6 @@
+use anyhow::{Context, Result};
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::FileExt;
-use anyhow::{Context, Result};
 
 pub struct RawPortIo {
     file: File,
@@ -18,7 +18,8 @@ impl RawPortIo {
 
     #[inline(always)]
     pub fn outb(&self, port: u16, val: u8) -> Result<()> {
-        self.file.write_at(&[val], port as u64)
+        self.file
+            .write_at(&[val], port as u64)
             .with_context(|| format!("outb failed at port {:#X}", port))?;
         Ok(())
     }
@@ -26,7 +27,8 @@ impl RawPortIo {
     #[inline(always)]
     pub fn inb(&self, port: u16) -> Result<u8> {
         let mut buf = [0u8; 1];
-        self.file.read_at(&mut buf, port as u64)
+        self.file
+            .read_at(&mut buf, port as u64)
             .with_context(|| format!("inb failed at port {:#X}", port))?;
         Ok(buf[0])
     }

--- a/daemon/src/ec/sys_windows.rs
+++ b/daemon/src/ec/sys_windows.rs
@@ -17,14 +17,20 @@ pub struct RawPortIo {
 impl RawPortIo {
     pub fn new() -> Result<Self> {
         unsafe {
-            let lib = Library::new("inpoutx64.dll")
-                .map_err(|_| anyhow::anyhow!("Failed to load inpoutx64.dll. Ensure it's placed next to daemon.exe."))?;
+            let lib = Library::new("inpoutx64.dll").map_err(|_| {
+                anyhow::anyhow!(
+                    "Failed to load inpoutx64.dll. Ensure it's placed next to daemon.exe."
+                )
+            })?;
 
-            let is_open_sym: Symbol<IsDriverOpenFn> = lib.get(b"IsInpOutDriverOpen\0")
-                    .context("IsInpOutDriverOpen export not found in DLL")?;
-            let out32_sym: Symbol<Out32Fn> = lib.get(b"Out32\0")
+            let is_open_sym: Symbol<IsDriverOpenFn> = lib
+                .get(b"IsInpOutDriverOpen\0")
+                .context("IsInpOutDriverOpen export not found in DLL")?;
+            let out32_sym: Symbol<Out32Fn> = lib
+                .get(b"Out32\0")
                 .context("Out32 export not found in DLL")?;
-            let inp32_sym: Symbol<Inp32Fn> = lib.get(b"Inp32\0")
+            let inp32_sym: Symbol<Inp32Fn> = lib
+                .get(b"Inp32\0")
                 .context("Inp32 export not found in DLL")?;
 
             let is_open = *is_open_sym;
@@ -54,8 +60,6 @@ impl RawPortIo {
 
     #[inline(always)]
     pub fn inb(&self, port: u16) -> Result<u8> {
-        unsafe {
-            Ok((self.inp32)(port as i32))
-        }
+        unsafe { Ok((self.inp32)(port as i32)) }
     }
 }

--- a/daemon/src/handlers.rs
+++ b/daemon/src/handlers.rs
@@ -1,6 +1,12 @@
-use ipc::{ChargeLimit, CurrentSettings, DaemonCommand, DaemonResponse, FanIndex, FanMode, IpcRequest, IpcResponse, KeyboardBacklightLevel, PowerLedMode, PowerProfile};
+use crate::{
+    ec::{self, EcDevice},
+    telemetry,
+};
 use anyhow::{Context, Result, anyhow};
-use crate::{ec::{self, EcDevice}, telemetry};
+use ipc::{
+    ChargeLimit, CurrentSettings, DaemonCommand, DaemonResponse, FanIndex, FanMode, IpcRequest,
+    IpcResponse, KeyboardBacklightLevel, PowerLedMode, PowerProfile,
+};
 
 #[cfg(windows)]
 const STATE_PATH: &str = "C:\\ProgramData\\LecooControl\\daemon_state.bin";
@@ -10,13 +16,15 @@ const STATE_PATH: &str = "/var/lib/lecoo-control/daemon_state.bin";
 pub trait DaemonState: Sized {
     fn load() -> Result<Self>;
     fn load_or_default() -> Self;
-    fn save(&self) -> Result<()> ;
+    fn save(&self) -> Result<()>;
     fn restore_state(&self, ec: &EcDevice) -> Result<()>;
 }
 
 impl DaemonState for CurrentSettings {
     fn save(&self) -> Result<()> {
-        let dir = std::path::Path::new(STATE_PATH).parent().context("Invalid state path")?;
+        let dir = std::path::Path::new(STATE_PATH)
+            .parent()
+            .context("Invalid state path")?;
         std::fs::create_dir_all(dir)?;
 
         let file = std::fs::File::create(STATE_PATH)?;
@@ -34,11 +42,14 @@ impl DaemonState for CurrentSettings {
         let file = std::fs::File::open(STATE_PATH).context("Failed to open state file")?;
         let mut reader = std::io::BufReader::new(file);
 
-        bincode::decode_from_std_read(&mut reader, bincode::config::standard()).context("Failed decode state file!")
+        bincode::decode_from_std_read(&mut reader, bincode::config::standard())
+            .context("Failed decode state file!")
     }
 
     fn load_or_default() -> Self {
-        Self::load().map_err(|err| log::error!("Load state error: {}", err)).unwrap_or_default()
+        Self::load()
+            .map_err(|err| log::error!("Load state error: {}", err))
+            .unwrap_or_default()
     }
 
     fn restore_state(&self, ec: &EcDevice) -> Result<()> {
@@ -62,6 +73,8 @@ pub fn do_work(req: &IpcRequest) -> IpcResponse {
         IpcRequest::GetFansRPM => get_fans_rpm(ec),
 
         IpcRequest::GetTemperatures => get_temperatures(ec),
+
+        IpcRequest::GetMonitoring => get_monitoring(ec),
 
         IpcRequest::GetChargeLimit => get_charge_limit(ec),
 
@@ -98,7 +111,7 @@ fn process_daemon_command(ec: &EcDevice, command: &DaemonCommand) -> Result<IpcR
             state.save()?;
             state.restore_state(ec)?;
             Ok(IpcResponse::Success)
-        },
+        }
 
         DaemonCommand::ActivateTelemetry(is_enabled) => {
             let mut state = get_state()?;
@@ -112,18 +125,22 @@ fn process_daemon_command(ec: &EcDevice, command: &DaemonCommand) -> Result<IpcR
                 telemetry::disable();
                 Ok(IpcResponse::TelemetryDisabledInfo)
             }
-        },
+        }
 
         DaemonCommand::ApplySettings => {
             let state = get_state()?;
-            state.restore_state(&ec)?;
+            state.restore_state(ec)?;
             Ok(IpcResponse::Success)
         }
-        DaemonCommand::GetSettings => Ok(IpcResponse::DaemonResponse(DaemonResponse::Settings(get_state()?.clone()))),
-        DaemonCommand::GetTelemetryId => Ok(IpcResponse::DaemonResponse(DaemonResponse::TelemetryId(get_state()?.telemetry_client_id))),
+        DaemonCommand::GetSettings => Ok(IpcResponse::DaemonResponse(DaemonResponse::Settings(
+            *get_state()?,
+        ))),
+        DaemonCommand::GetTelemetryId => Ok(IpcResponse::DaemonResponse(
+            DaemonResponse::TelemetryId(get_state()?.telemetry_client_id),
+        )),
 
         // todo: suspend/resume
-        _ => todo!()
+        _ => todo!(),
     }
 }
 
@@ -151,7 +168,12 @@ fn get_system_state(ec: &EcDevice) -> Result<IpcResponse> {
     let chip_name = format!("IT{:02X}{:02X}", chip_id1, chip_id2);
     let revision = format!("{:02X}", chip_ver);
 
-    Ok(IpcResponse::SystemInfo(chip_name, revision, ec.hram_offset, crate::VERSION.to_string()))
+    Ok(IpcResponse::SystemInfo(
+        chip_name,
+        revision,
+        ec.hram_offset,
+        crate::VERSION.to_string(),
+    ))
 }
 
 fn get_fans_rpm(ec: &EcDevice) -> Result<IpcResponse> {
@@ -162,6 +184,14 @@ fn get_fans_rpm(ec: &EcDevice) -> Result<IpcResponse> {
 fn get_temperatures(ec: &EcDevice) -> Result<IpcResponse> {
     let (cpu_temp, sys_temp) = ec::read_temperatures(ec)?;
     Ok(IpcResponse::Temp(cpu_temp, sys_temp))
+}
+
+fn get_monitoring(ec: &EcDevice) -> Result<IpcResponse> {
+    let (cpu_temp, sys_temp) = ec::read_temperatures(ec)?;
+    let (cpu_rpm, gpu_rpm) = ec::read_fans_rpm(ec)?;
+    Ok(IpcResponse::Monitoring(
+        cpu_temp, sys_temp, cpu_rpm, gpu_rpm,
+    ))
 }
 
 // Setters
@@ -176,7 +206,7 @@ pub fn get_state() -> Result<std::sync::MutexGuard<'static, CurrentSettings>> {
 }
 
 fn set_charge_limit(ec: &EcDevice, profile: &ChargeLimit) -> Result<IpcResponse> {
-    ec::apply_charge_limit(ec, &profile)?;
+    ec::apply_charge_limit(ec, profile)?;
     let mut state = get_state()?;
     state.charge_limit = *profile;
 
@@ -197,13 +227,17 @@ fn set_fan_mode(ec: &EcDevice, fan: &FanIndex, mode: &FanMode) -> Result<IpcResp
     match fan {
         FanIndex::Cpu => state.fan_mode_cpu = *mode,
         FanIndex::Gpu => state.fan_mode_gpu = *mode,
+        FanIndex::Both => {
+            state.fan_mode_cpu = *mode;
+            state.fan_mode_gpu = *mode;
+        }
     }
 
     Ok(IpcResponse::Success)
 }
 
 fn set_power_profile(ec: &EcDevice, profile: &PowerProfile) -> Result<IpcResponse> {
-    ec::apply_power_profile(ec, &profile)?;
+    ec::apply_power_profile(ec, profile)?;
     let mut state = get_state()?;
     state.power_profile = *profile;
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,9 +1,12 @@
 // #![windows_subsystem = "windows"]
 
-use anyhow::{Result, Context};
+use anyhow::Result;
 use ipc::{ChargeLimit, CurrentSettings, IpcConnection, IpcRequest, IpcServer};
 use log::info;
-use std::{sync::{Mutex, OnceLock}, thread};
+use std::{
+    sync::{Mutex, OnceLock},
+    thread,
+};
 
 use crate::handlers::DaemonState;
 
@@ -43,9 +46,7 @@ fn process_ipc_connection(mut conn: IpcConnection) {
                         if let Ok(state) = STATE.get().unwrap().try_lock() {
                             let _ = state.save();
                         } else {
-                            log::warn!(
-                                "Could not acquire lock to save state on connection reset"
-                            );
+                            log::warn!("Could not acquire lock to save state on connection reset");
                         }
                     }
                     break;
@@ -57,16 +58,16 @@ fn process_ipc_connection(mut conn: IpcConnection) {
 
 /// Process system/service events
 fn process_service(rx_in_core: std::sync::mpsc::Receiver<services::InternalEvent>) {
-    use ipc::{PowerLedMode, BreathConfig};
+    use ipc::{BreathConfig, PowerLedMode};
     let ec = EC.get().unwrap();
     let read_and_save_state = |ec: &ec::EcDevice| {
         if let Ok(mut state) = handlers::get_state() {
             let _ = ec::read_keyboard_backlight(ec).map(|kbd| state.keyboard_backlight = kbd);
             let _ = ec::read_power_profile(ec).map(|profile| state.power_profile = profile);
-            if let Ok((min, max)) = ec::read_charge_limit(ec) {
-                if let Some(limit) = ChargeLimit::from_predefined(min, max) {
-                    state.charge_limit = limit;
-                }
+            if let Ok((min, max)) = ec::read_charge_limit(ec)
+                && let Some(limit) = ChargeLimit::from_predefined(min, max)
+            {
+                state.charge_limit = limit;
             }
             let _ = state.save();
         } else {
@@ -74,49 +75,42 @@ fn process_service(rx_in_core: std::sync::mpsc::Receiver<services::InternalEvent
         }
     };
 
-    loop {
-        match rx_in_core.recv() {
-            Ok(event) => {
-                match event {
-                    services::InternalEvent::SystemShuttingDown | services::InternalEvent::SystemHibernating => {
-                        let _ = ec::apply_led_mode(ec, &PowerLedMode::Auto);
-                        read_and_save_state(ec);
-                    }
-
-                    services::InternalEvent::SystemSleeping => {
-                        let _ = ec::apply_led_mode(
-                            ec,
-                            &PowerLedMode::Animation(BreathConfig::sleep()),
-                        );
-                        read_and_save_state(ec);
-                    }
-
-                    services::InternalEvent::SystemWakingUp => {
-                        let _ = handlers::get_state().map(|state| state.restore_state(ec));
-                    }
-
-                    services::InternalEvent::ChargerConnected => {
-                        if let Ok(current) = ec::read_battery_rsoc(ec) {
-                            if let Ok(charge_limits) = ec::read_charge_limit(ec) {
-                                if current >= charge_limits.1 {
-                                    let _ = ec::apply_battery_leds(ec, false, true);
-                                } else {
-                                    let _ = ec::apply_battery_leds(ec, true, false);
-                                }
-                            }
-                        }
-                    }
-
-                    services::InternalEvent::ChargerDisconnected => {
-                        let _ = ec::apply_battery_leds(ec, false, false);
-                    }
-
-                    #[cfg(windows)]
-                    services::InternalEvent::Inited => {}
-                };
+    while let Ok(event) = rx_in_core.recv() {
+        match event {
+            services::InternalEvent::SystemShuttingDown
+            | services::InternalEvent::SystemHibernating => {
+                let _ = ec::apply_led_mode(ec, &PowerLedMode::Auto);
+                read_and_save_state(ec);
             }
-            Err(_) => break,
-        }
+
+            services::InternalEvent::SystemSleeping => {
+                let _ = ec::apply_led_mode(ec, &PowerLedMode::Animation(BreathConfig::sleep()));
+                read_and_save_state(ec);
+            }
+
+            services::InternalEvent::SystemWakingUp => {
+                let _ = handlers::get_state().map(|state| state.restore_state(ec));
+            }
+
+            services::InternalEvent::ChargerConnected => {
+                if let Ok(current) = ec::read_battery_rsoc(ec)
+                    && let Ok(charge_limits) = ec::read_charge_limit(ec)
+                {
+                    if current >= charge_limits.1 {
+                        let _ = ec::apply_battery_leds(ec, false, true);
+                    } else {
+                        let _ = ec::apply_battery_leds(ec, true, false);
+                    }
+                }
+            }
+
+            services::InternalEvent::ChargerDisconnected => {
+                let _ = ec::apply_battery_leds(ec, false, false);
+            }
+
+            #[cfg(windows)]
+            services::InternalEvent::Inited => {}
+        };
     }
 }
 
@@ -132,8 +126,12 @@ fn main() -> Result<()> {
         let _ = rx_in_core.recv();
         thread::sleep(std::time::Duration::from_secs(2));
     } else {
-        println!("The daemon has been launched in manual mode! Please, run it as a service. Otherwise, it will not work properly.");
-        log::warn!("The daemon has been launched in manual mode! Please, run it as a service. Otherwise, it will not work properly.");
+        println!(
+            "The daemon has been launched in manual mode! Please, run it as a service. Otherwise, it will not work properly."
+        );
+        log::warn!(
+            "The daemon has been launched in manual mode! Please, run it as a service. Otherwise, it will not work properly."
+        );
     }
 
     // Linux just start the service
@@ -141,12 +139,14 @@ fn main() -> Result<()> {
     let _service_worker = services::start(tx_to_core);
 
     let mut server = IpcServer::bind().map_err(|e| {
-        log::error!("Failed to bind IPC server: {}", e); e
+        log::error!("Failed to bind IPC server: {}", e);
+        e
     })?;
 
     let insecure_mode = args.iter().any(|arg| arg == "--insecure");
     let ec = ec::EcDevice::new(insecure_mode).map_err(|e| {
-        log::error!("Failed to initialize EC device: {}", e); e
+        log::error!("Failed to initialize EC device: {}", e);
+        e
     })?;
 
     let daemon_state = CurrentSettings::load_or_default();
@@ -154,7 +154,10 @@ fn main() -> Result<()> {
         log::error!("Failed to restore EC state: {}", e);
     }
 
-    telemetry::init(daemon_state.telemetry_enabled, daemon_state.telemetry_client_id);
+    telemetry::init(
+        daemon_state.telemetry_enabled,
+        daemon_state.telemetry_client_id,
+    );
 
     if daemon_state.telemetry_enabled {
         let (cpu_name, os_name, motherboard) = services::get_system_info();
@@ -172,7 +175,7 @@ fn main() -> Result<()> {
     let _ = EC.set(ec);
     let _ = STATE.set(Mutex::new(daemon_state));
 
-    #[cfg(target_os="linux")]
+    #[cfg(target_os = "linux")]
     println!("Daemon started. For reading logs: \"journalctl -t lecoo-daemon -f\"");
     info!("Daemon started.");
 

--- a/daemon/src/services/mod.rs
+++ b/daemon/src/services/mod.rs
@@ -1,15 +1,15 @@
 #![allow(dead_code)]
 use std::{sync::mpsc::Sender, thread::JoinHandle};
 
-#[cfg(target_os = "windows")]
-pub mod win_service;
 #[cfg(target_os = "linux")]
 pub mod systemd_service;
-
 #[cfg(target_os = "windows")]
-pub use win_service::{init_logger, get_system_info, get_board_name};
+pub mod win_service;
+
 #[cfg(target_os = "linux")]
-pub use systemd_service::{init_logger, get_system_info, get_board_name};
+pub use systemd_service::{get_board_name, get_system_info, init_logger};
+#[cfg(target_os = "windows")]
+pub use win_service::{get_board_name, get_system_info, init_logger};
 
 #[derive(Debug, Clone, Copy)]
 pub enum InternalEvent {

--- a/daemon/src/services/systemd_service.rs
+++ b/daemon/src/services/systemd_service.rs
@@ -1,15 +1,16 @@
+use super::InternalEvent;
 use std::fs;
 use std::sync::mpsc::Sender;
 use std::{panic, thread};
 use zbus::blocking::Connection;
-use super::InternalEvent;
 
 pub fn init_logger() {
     systemd_journal_logger::JournalLog::new()
         .unwrap()
         .with_extra_fields(vec![("VERSION", crate::VERSION)])
         .with_syslog_identifier("lecoo-daemon".to_string())
-        .install().unwrap();
+        .install()
+        .unwrap();
     log::set_max_level(log::LevelFilter::Info);
 
     panic::set_hook(Box::new(|panic_info| {
@@ -31,9 +32,9 @@ pub fn init_logger() {
         );
 
         log::error!("{}", error);
-        crate::telemetry::send(
-            ipc::TelemetryData::Panic { error: error.clone() }
-        );
+        crate::telemetry::send(ipc::TelemetryData::Panic {
+            error: error.clone(),
+        });
     }));
 }
 
@@ -48,7 +49,12 @@ trait SystemdManager {
 
     /// New signal for systemd job creation
     #[zbus(signal)]
-    fn job_new(&self, id: u32, job: zbus::zvariant::OwnedObjectPath, unit: String) -> zbus::Result<()>;
+    fn job_new(
+        &self,
+        id: u32,
+        job: zbus::zvariant::OwnedObjectPath,
+        unit: String,
+    ) -> zbus::Result<()>;
 }
 
 #[zbus::proxy(
@@ -96,7 +102,10 @@ pub fn run_as_service(tx: Sender<InternalEvent>) -> zbus::Result<()> {
         .spawn(move || {
             let manager = match SystemdManagerProxyBlocking::new(&conn_systemd) {
                 Ok(m) => m,
-                Err(e) => { log::error!("systemd proxy error: {e}"); return; }
+                Err(e) => {
+                    log::error!("systemd proxy error: {e}");
+                    return;
+                }
             };
 
             if let Err(e) = manager.subscribe() {
@@ -106,18 +115,26 @@ pub fn run_as_service(tx: Sender<InternalEvent>) -> zbus::Result<()> {
 
             let signals = match manager.receive_job_new() {
                 Ok(s) => s,
-                Err(e) => { log::error!("job_new subscribe error: {e}"); return; }
+                Err(e) => {
+                    log::error!("job_new subscribe error: {e}");
+                    return;
+                }
             };
 
             for sig in signals {
                 let Ok(args) = sig.args() else { continue };
 
-                let is_sleep_unit = match args.unit.as_str() {
-                    "suspend.target" | "hibernate.target" | "hybrid-sleep.target" | "suspend-then-hibernate.target" => true,
-                    _ => false,
-                };
+                let is_sleep_unit = matches!(
+                    args.unit.as_str(),
+                    "suspend.target"
+                        | "hibernate.target"
+                        | "hybrid-sleep.target"
+                        | "suspend-then-hibernate.target"
+                );
 
-                if !is_sleep_unit { continue; }
+                if !is_sleep_unit {
+                    continue;
+                }
 
                 if let Ok(job_proxy) = SystemdJobProxyBlocking::builder(&conn_systemd)
                     .path(args.job.clone())
@@ -153,20 +170,24 @@ pub fn run_as_service(tx: Sender<InternalEvent>) -> zbus::Result<()> {
         .spawn(move || {
             let proxy = match LoginManagerProxyBlocking::new(&conn_sleep) {
                 Ok(p) => p,
-                Err(e) => { log::error!("sleep proxy: {e}"); return; }
+                Err(e) => {
+                    log::error!("sleep proxy: {e}");
+                    return;
+                }
             };
             let signals = match proxy.receive_prepare_for_sleep() {
                 Ok(s) => s,
-                Err(e) => { log::error!("sleep subscribe: {e}"); return; }
+                Err(e) => {
+                    log::error!("sleep subscribe: {e}");
+                    return;
+                }
             };
 
             for sig in signals {
                 let Ok(args) = sig.args() else { continue };
 
-                if !args.start {
-                    if tx_sleep.send(InternalEvent::SystemWakingUp).is_err() {
-                        break;
-                    }
+                if !args.start && tx_sleep.send(InternalEvent::SystemWakingUp).is_err() {
+                    break;
                 }
             }
         })
@@ -180,7 +201,10 @@ pub fn run_as_service(tx: Sender<InternalEvent>) -> zbus::Result<()> {
         .spawn(move || {
             let proxy = match UPowerProxyBlocking::new(&conn_power) {
                 Ok(p) => p,
-                Err(e) => { log::error!("upower proxy error: {e}"); return; }
+                Err(e) => {
+                    log::error!("upower proxy error: {e}");
+                    return;
+                }
             };
 
             let changed_stream = proxy.receive_on_battery_changed();

--- a/daemon/src/services/win_service.rs
+++ b/daemon/src/services/win_service.rs
@@ -1,22 +1,26 @@
+use file_rotate::compression::Compression;
+use file_rotate::suffix::AppendCount;
+use file_rotate::{ContentLimit, FileRotate};
+use ipc::TelemetryData;
+use log::{LevelFilter, info};
+use simplelog::{Config, WriteLogger};
 use std::fs::create_dir_all;
 use std::panic;
 use std::path::Path;
 use std::sync::{OnceLock, mpsc::Sender};
 use std::time::Duration;
-use file_rotate::compression::Compression;
-use file_rotate::suffix::AppendCount;
-use file_rotate::{ContentLimit, FileRotate};
-use ipc::TelemetryData;
-use winreg::enums::*;
-use winreg::RegKey;
-use log::{LevelFilter, info};
-use simplelog::{Config, WriteLogger};
 use windows_service::service::ServiceType;
 use windows_service::{
-    define_windows_service, service::{
-        PowerEventParam, ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus
-    }, service_control_handler::{self, ServiceControlHandlerResult}, service_dispatcher
+    define_windows_service,
+    service::{
+        PowerEventParam, ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState,
+        ServiceStatus,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult},
+    service_dispatcher,
 };
+use winreg::RegKey;
+use winreg::enums::*;
 
 use crate::services::InternalEvent;
 
@@ -40,16 +44,22 @@ pub fn get_board_name() -> String {
 pub fn get_system_info() -> (String, String, String) {
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
 
-    let cpu_name = hklm.open_subkey("HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0")
+    let cpu_name = hklm
+        .open_subkey("HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0")
         .and_then(|key| key.get_value::<String, _>("ProcessorNameString"))
         .unwrap_or_else(|_| "Unknown CPU".to_string());
 
     let motherboard = get_board_name();
 
-    let (mut os_name, os_version) = hklm.open_subkey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion")
+    let (mut os_name, os_version) = hklm
+        .open_subkey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion")
         .map(|key| {
-            let name = key.get_value::<String, _>("ProductName").unwrap_or_else(|_| "Windows".to_string());
-            let build = key.get_value::<String, _>("CurrentBuild").unwrap_or_else(|_| "0".to_string());
+            let name = key
+                .get_value::<String, _>("ProductName")
+                .unwrap_or_else(|_| "Windows".to_string());
+            let build = key
+                .get_value::<String, _>("CurrentBuild")
+                .unwrap_or_else(|_| "0".to_string());
             (name, build)
         })
         .unwrap_or_else(|_| ("Windows".to_string(), "0".to_string()));
@@ -61,7 +71,11 @@ pub fn get_system_info() -> (String, String, String) {
         os_name = os_name.replace("Windows 10", "Windows 11");
     }
 
-    (cpu_name, format!("{} (Build {})", os_name, os_version), motherboard)
+    (
+        cpu_name,
+        format!("{} (Build {})", os_name, os_version),
+        motherboard,
+    )
 }
 
 fn my_service_main(_arguments: Vec<std::ffi::OsString>) {
@@ -103,8 +117,7 @@ fn my_service_main(_arguments: Vec<std::ffi::OsString>) {
                             let _ = tx.send(InternalEvent::SystemHibernating);
                         }
 
-                        PowerEventParam::ResumeAutomatic
-                        | PowerEventParam::ResumeSuspend => {
+                        PowerEventParam::ResumeAutomatic | PowerEventParam::ResumeSuspend => {
                             let _ = tx.send(InternalEvent::SystemWakingUp);
                         }
 
@@ -115,15 +128,16 @@ fn my_service_main(_arguments: Vec<std::ffi::OsString>) {
                 _ => ServiceControlHandlerResult::NotImplemented,
             }
         },
-    ).expect("Failed to register service control handler");
+    )
+    .expect("Failed to register service control handler");
 
     // Notify the Service Control Manager that the service is running & ready
     let next_status = ServiceStatus {
         service_type: ServiceType::OWN_PROCESS,
         current_state: ServiceState::Running,
         controls_accepted: ServiceControlAccept::STOP
-                | ServiceControlAccept::POWER_EVENT
-                | ServiceControlAccept::SHUTDOWN,
+            | ServiceControlAccept::POWER_EVENT
+            | ServiceControlAccept::SHUTDOWN,
         exit_code: ServiceExitCode::Win32(0),
         checkpoint: 0,
         wait_hint: Duration::default(),
@@ -137,15 +151,17 @@ fn my_service_main(_arguments: Vec<std::ffi::OsString>) {
     std::thread::sleep(Duration::from_millis(500));
 
     info!("TIME TO STOP!");
-    status_handle.set_service_status(ServiceStatus {
-        service_type: ServiceType::OWN_PROCESS,
-        current_state: ServiceState::Stopped,
-        controls_accepted: ServiceControlAccept::empty(),
-        exit_code: ServiceExitCode::Win32(0),
-        checkpoint: 0,
-        wait_hint: Duration::default(),
-        process_id: None,
-    }).unwrap();
+    status_handle
+        .set_service_status(ServiceStatus {
+            service_type: ServiceType::OWN_PROCESS,
+            current_state: ServiceState::Stopped,
+            controls_accepted: ServiceControlAccept::empty(),
+            exit_code: ServiceExitCode::Win32(0),
+            checkpoint: 0,
+            wait_hint: Duration::default(),
+            process_id: None,
+        })
+        .unwrap();
 }
 
 #[repr(C)]
@@ -176,14 +192,11 @@ pub fn init_logger() {
         AppendCount::new(3),
         ContentLimit::Bytes(5 * 1024 * 1024),
         Compression::None,
-        None
+        None,
     );
 
-    WriteLogger::init(
-        LevelFilter::Info,
-        Config::default(),
-        writer
-    ).unwrap_or_else(|err| log::error!("Something try init logger again. {:?}", err));
+    WriteLogger::init(LevelFilter::Info, Config::default(), writer)
+        .unwrap_or_else(|err| log::error!("Something try init logger again. {:?}", err));
 
     panic::set_hook(Box::new(|panic_info| {
         let location = panic_info.location().unwrap();
@@ -205,8 +218,6 @@ pub fn init_logger() {
 
         log::error!("{}", error);
         log::logger().flush();
-        crate::telemetry::send(
-            TelemetryData::Panic { error }
-        );
+        crate::telemetry::send(TelemetryData::Panic { error });
     }));
 }

--- a/daemon/src/telemetry/mod.rs
+++ b/daemon/src/telemetry/mod.rs
@@ -1,10 +1,22 @@
-use std::{sync::{OnceLock, atomic::{AtomicBool, AtomicU64, Ordering}, mpsc::{Receiver, RecvTimeoutError, Sender}}, time::Duration};
+use std::{
+    sync::{
+        OnceLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::{Receiver, RecvTimeoutError, Sender},
+    },
+    time::Duration,
+};
 
 use ipc::{TelemetryData, TelemetryPayload};
 
 use crate::ec;
 
-static TELEMETRY_INTERVAL: Duration = Duration::from_secs(300);
+/// Status poll interval when telemetry is enabled.
+const TELEMETRY_INTERVAL_ENABLED: Duration = Duration::from_secs(300);
+/// Wakeup interval when telemetry is disabled. Much longer to save power;
+/// the worker still wakes occasionally so that re-enabling takes effect promptly.
+const TELEMETRY_INTERVAL_DISABLED: Duration = Duration::from_secs(1800);
+
 static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(true);
 static TELEMETRY_TX: OnceLock<Sender<TelemetryData>> = OnceLock::new();
 static TELEMETRY_ID: AtomicU64 = AtomicU64::new(0);
@@ -23,10 +35,10 @@ pub fn init(start_enabled: bool, client_id: u64) {
 }
 
 pub fn send(data: TelemetryData) {
-    if is_enabled() {
-        if let Some(tx) = TELEMETRY_TX.get() {
-            let _ = tx.send(data);
-        }
+    if is_enabled()
+        && let Some(tx) = TELEMETRY_TX.get()
+    {
+        let _ = tx.send(data);
     }
 }
 
@@ -46,28 +58,29 @@ pub fn is_enabled() -> bool {
 
 fn worker_loop(rx: Receiver<TelemetryData>) {
     loop {
-        match rx.recv_timeout(TELEMETRY_INTERVAL) {
+        let interval = if is_enabled() {
+            TELEMETRY_INTERVAL_ENABLED
+        } else {
+            TELEMETRY_INTERVAL_DISABLED
+        };
+        match rx.recv_timeout(interval) {
             Ok(message) => {
                 if is_enabled() {
                     send_to_server(message);
                 }
             }
             Err(RecvTimeoutError::Timeout) => {
-                if is_enabled() {
-                    if let Some(ec) = crate::EC.get() {
-                        if let Ok(profile) = ec::read_power_profile(ec) {
-                            if let Ok((cpu_temp, sys_temp)) = ec::read_temperatures(ec) {
-                                if let Ok((cpu_rpm, gpu_rpm)) = ec::read_fans_rpm(ec) {
-                                    let status = TelemetryData::Status {
-                                        profile,
-                                        temps: [cpu_temp as u32, sys_temp as u32],
-                                        fans: [cpu_rpm as u32, gpu_rpm as u32],
-                                    };
-                                    send_to_server(status);
-                                }
-                            }
-                        }
-                    }
+                if is_enabled()
+                    && let Some(ec) = crate::EC.get()
+                    && let Ok((profile, cpu_temp, sys_temp, cpu_rpm, gpu_rpm)) =
+                        ec::read_status_snapshot(ec)
+                {
+                    let status = TelemetryData::Status {
+                        profile,
+                        temps: [cpu_temp as u32, sys_temp as u32],
+                        fans: [cpu_rpm as u32, gpu_rpm as u32],
+                    };
+                    send_to_server(status);
                 }
             }
             Err(RecvTimeoutError::Disconnected) => {
@@ -81,10 +94,7 @@ fn worker_loop(rx: Receiver<TelemetryData>) {
 fn send_to_server(data: TelemetryData) {
     let id = TELEMETRY_ID.load(Ordering::Relaxed);
 
-    let payload = TelemetryPayload {
-        id,
-        data
-    };
+    let payload = TelemetryPayload { id, data };
 
     let config = bincode::config::standard();
     let encoded_bytes = match bincode::encode_to_vec(&payload, config) {
@@ -100,7 +110,7 @@ fn send_to_server(data: TelemetryData) {
         .header("Content-Type", "application/octet-stream")
         .send(&encoded_bytes)
     {
-        Ok(_response) => {},
+        Ok(_response) => {}
         Err(e) => log::warn!("Failed to send telemetry: {}", e),
     }
 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -1,2 +1,1 @@
-fn main() {
-}
+fn main() {}

--- a/ipc/src/client.rs
+++ b/ipc/src/client.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
-use bincode::{Decode, Encode};
 use crate::{IpcConnection, get_socket_name};
+use bincode::{Decode, Encode};
 
 pub struct IpcClient {
     conn: IpcConnection,
@@ -16,7 +16,13 @@ impl IpcClient {
             .connect_sync()?;
 
         // Handshake
-        let handshake = [b'L', b'C', b'C', crate::IPC_PROTOCOL_VERSION[0], crate::IPC_PROTOCOL_VERSION[1]];
+        let handshake = [
+            b'L',
+            b'C',
+            b'C',
+            crate::IPC_PROTOCOL_VERSION[0],
+            crate::IPC_PROTOCOL_VERSION[1],
+        ];
         stream.write_all(&handshake)?;
 
         let mut resp = [0u8; 5];
@@ -27,18 +33,25 @@ impl IpcClient {
         if &resp[0..3] == b"ERR" {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::ConnectionRefused,
-                format!("Daemon rejected connection: Version mismatch! Daemon is v{}.{}, Client is v{}.{}.{}. Please update.",
-                    daemon_major_ver, daemon_minor_ver,
-                    crate::IPC_PROTOCOL_VERSION[0], crate::IPC_PROTOCOL_VERSION[1], crate::IPC_PROTOCOL_VERSION[2]
-                )
+                format!(
+                    "Daemon rejected connection: Version mismatch! Daemon is v{}.{}, Client is v{}.{}.{}. Please update.",
+                    daemon_major_ver,
+                    daemon_minor_ver,
+                    crate::IPC_PROTOCOL_VERSION[0],
+                    crate::IPC_PROTOCOL_VERSION[1],
+                    crate::IPC_PROTOCOL_VERSION[2]
+                ),
             ));
         } else if &resp[0..3] != b"OKK" {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid IPC handshake"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid IPC handshake",
+            ));
         }
 
         Ok(Self {
             conn: IpcConnection { stream },
-            daemon_version: (daemon_major_ver, daemon_minor_ver)
+            daemon_version: (daemon_major_ver, daemon_minor_ver),
         })
     }
 

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -1,6 +1,6 @@
 use bincode::{Decode, Encode, config};
 use interprocess::local_socket::{GenericNamespaced, Stream, ToNsName};
-use std::io::{Read, self, Write};
+use std::io::{self, Read, Write};
 
 mod client;
 mod server;
@@ -27,6 +27,9 @@ pub enum IpcRequest {
     /// Get system temperatures
     GetTemperatures,
 
+    /// Get both temperatures and fan RPMs atomically (single round-trip).
+    GetMonitoring,
+
     /// Get the current battery charge limit
     GetChargeLimit,
 
@@ -40,10 +43,7 @@ pub enum IpcRequest {
     SetPowerProfile(PowerProfile),
 
     /// Set a specific fan's mode (Auto/Full/Custom)
-    SetFanMode {
-        fan: FanIndex,
-        mode: FanMode,
-    },
+    SetFanMode { fan: FanIndex, mode: FanMode },
 
     /// Set keyboard backlight brightness
     SetKeyboardBacklight(KeyboardBacklightLevel),
@@ -57,7 +57,6 @@ pub enum IpcRequest {
     /// Send a command to the daemon
     DaemonCommand(DaemonCommand),
 }
-
 
 /// Responses sent FROM the Daemon TO the Client.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
@@ -73,6 +72,9 @@ pub enum IpcResponse {
 
     /// Temperature readings for CPU and System
     Temp(u8, u8),
+
+    /// Combined monitoring snapshot: (cpu_temp, sys_temp, cpu_rpm, gpu_rpm)
+    Monitoring(u8, u8, u16, u16),
 
     /// Current battery charge limit (min/max percentages)
     ChargeLimit(u8, u8, u8),
@@ -103,25 +105,45 @@ impl IpcConnection {
         self.stream.read_exact(&mut req)?;
 
         if &req[0..3] != b"LCC" {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid magic bytes"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid magic bytes",
+            ));
         }
 
         let client_major_ver = req[3];
         let client_minor_ver = req[4];
 
-        if client_major_ver != IPC_PROTOCOL_VERSION[0] || client_minor_ver != IPC_PROTOCOL_VERSION[1] {
-            let resp = [b'E', b'R', b'R', IPC_PROTOCOL_VERSION[0], IPC_PROTOCOL_VERSION[1]];
+        if client_major_ver != IPC_PROTOCOL_VERSION[0]
+            || client_minor_ver != IPC_PROTOCOL_VERSION[1]
+        {
+            let resp = [
+                b'E',
+                b'R',
+                b'R',
+                IPC_PROTOCOL_VERSION[0],
+                IPC_PROTOCOL_VERSION[1],
+            ];
             let _ = self.stream.write_all(&resp);
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Version mismatch. Client: v{}.{}, Server: v{}.{}",
-                    client_major_ver, client_minor_ver,
-                    IPC_PROTOCOL_VERSION[0], IPC_PROTOCOL_VERSION[1]
-                )
+                format!(
+                    "Version mismatch. Client: v{}.{}, Server: v{}.{}",
+                    client_major_ver,
+                    client_minor_ver,
+                    IPC_PROTOCOL_VERSION[0],
+                    IPC_PROTOCOL_VERSION[1]
+                ),
             ));
         }
 
-        let resp = [b'O', b'K', b'K', IPC_PROTOCOL_VERSION[0], IPC_PROTOCOL_VERSION[1]];
+        let resp = [
+            b'O',
+            b'K',
+            b'K',
+            IPC_PROTOCOL_VERSION[0],
+            IPC_PROTOCOL_VERSION[1],
+        ];
         self.stream.write_all(&resp)?;
 
         Ok(())
@@ -148,9 +170,15 @@ impl IpcConnection {
             let n = self.stream.read(&mut len_bytes[bytes_read..])?;
             if n == 0 {
                 if bytes_read == 0 {
-                    return Err(io::Error::new(io::ErrorKind::ConnectionReset, "Connection reset by peer"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "Connection reset by peer",
+                    ));
                 } else {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "Connection dropped while reading"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "Connection dropped while reading",
+                    ));
                 }
             }
             bytes_read += n;
@@ -162,11 +190,17 @@ impl IpcConnection {
         self.stream.read_exact(&mut msg_version)?;
 
         if msg_version[0] != IPC_PROTOCOL_VERSION[0] || msg_version[1] != IPC_PROTOCOL_VERSION[1] {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "IPC protocol version mismatch"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "IPC protocol version mismatch",
+            ));
         }
 
         if len > 5 * 1024 * 1024 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "IPC payload too large"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "IPC payload too large",
+            ));
         }
 
         let mut data = vec![0u8; len];

--- a/ipc/src/structs.rs
+++ b/ipc/src/structs.rs
@@ -21,7 +21,6 @@ pub enum DaemonCommand {
 pub enum DaemonResponse {
     Settings(CurrentSettings),
     TelemetryId(u64),
-
 }
 
 /// Represents the power profiles
@@ -68,9 +67,9 @@ impl std::fmt::Display for KeyboardBacklightLevel {
 /// Represents the fan control mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum FanMode {
-    Auto,           // Controlled by EC thermal tables
-    Full,           // 100% speed override (Turbo)
-    Custom(u8),     // Custom PWM duty cycle
+    Auto,       // Controlled by EC thermal tables
+    Full,       // 100% speed override (Turbo)
+    Custom(u8), // Custom PWM duty cycle
 }
 
 /// Identifies the specific fan
@@ -78,17 +77,19 @@ pub enum FanMode {
 pub enum FanIndex {
     Cpu = 0x4B,
     Gpu = 0x4D,
+    /// Both fans. Daemon handles dispatching to Cpu and Gpu.
+    Both = 0xFF,
 }
 
 /// Represents battery charge limit profiles (FlexiCharger)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum ChargeLimit {
-    FullCapacity,       // 100%
-    HighCapacity,       // 95%
-    Balanced,           // 80%
-    MaximumLifespan,    // 60%
-    DeskMode,           // 40%
-    // Custom(u8),  // TODO: too dangerous, I think?
+    FullCapacity,    // 100%
+    HighCapacity,    // 95%
+    Balanced,        // 80%
+    MaximumLifespan, // 60%
+    DeskMode,        // 40%
+                     // Custom(u8),  // TODO: too dangerous, I think?
 }
 impl ChargeLimit {
     pub fn as_percent(&self) -> (u8, u8) {
@@ -102,7 +103,8 @@ impl ChargeLimit {
         }
     }
 
-    pub fn from_predefined(min: u8, max: u8) -> Option<Self> { // todo: wait, oh fck this is bad..
+    pub fn from_predefined(min: u8, max: u8) -> Option<Self> {
+        // todo: wait, oh fck this is bad..
         if min > max {
             return None;
         }
@@ -125,7 +127,6 @@ pub enum PowerLedMode {
     Animation(BreathConfig),
 }
 
-
 /// Represents breathing animation brightness levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum BreathBrightness {
@@ -147,13 +148,13 @@ pub enum BreathStep {
 /// Represents breathing animation delay durations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum BreathDelay {
-    Ms15 = 0x00,        // ~15.6 ms
-    Ms125 = 0x01,       // ~125 ms
-    Ms250 = 0x02,       // ~250 ms
-    Sec0_5 = 0x03,      // 0.5 sec
-    Sec1 = 0x04,        // 1.0 sec
-    Sec2 = 0x05,        // 2.0 sec
-    Sec4 = 0x06,        // 4.0 sec
+    Ms15 = 0x00,   // ~15.6 ms
+    Ms125 = 0x01,  // ~125 ms
+    Ms250 = 0x02,  // ~250 ms
+    Sec0_5 = 0x03, // 0.5 sec
+    Sec1 = 0x04,   // 1.0 sec
+    Sec2 = 0x05,   // 2.0 sec
+    Sec4 = 0x06,   // 4.0 sec
 }
 
 /// Represents breathing animation configuration
@@ -198,7 +199,7 @@ impl BreathConfig {
             max_brightness: BreathBrightness::Max75Percent,
             step_up: BreathStep::Instant,
             step_down: BreathStep::Instant,
-            delay_at_max: BreathDelay::Ms125 ,
+            delay_at_max: BreathDelay::Ms125,
             delay_at_min: BreathDelay::Ms125,
         }
     }
@@ -269,8 +270,8 @@ impl BreathConfig {
             max_brightness: BreathBrightness::Max100Percent,
             step_up: BreathStep::Instant,
             step_down: BreathStep::Instant,
-            delay_at_max: BreathDelay::Ms15,  // Minimum hardware delay
-            delay_at_min: BreathDelay::Ms15,  // Minimum hardware delay
+            delay_at_max: BreathDelay::Ms15, // Minimum hardware delay
+            delay_at_min: BreathDelay::Ms15, // Minimum hardware delay
         }
     }
 
@@ -341,9 +342,20 @@ impl Default for CurrentSettings {
 // V1: Old format without motherboard field (for backward compatibility)
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum TelemetryDataV1 {
-    Startup { firmware: String, offset: u16, cpu: String, os: String },
-    Status { profile: PowerProfile, temps: [u32; 2], fans: [u32; 2] },
-    Panic { error: String },
+    Startup {
+        firmware: String,
+        offset: u16,
+        cpu: String,
+        os: String,
+    },
+    Status {
+        profile: PowerProfile,
+        temps: [u32; 2],
+        fans: [u32; 2],
+    },
+    Panic {
+        error: String,
+    },
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
@@ -355,9 +367,21 @@ pub struct TelemetryPayloadV1 {
 // V2: Current format with motherboard field
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum TelemetryData {
-    Startup { firmware: String, offset: u16, cpu: String, os: String, motherboard: String },
-    Status { profile: PowerProfile, temps: [u32; 2], fans: [u32; 2] },
-    Panic { error: String },
+    Startup {
+        firmware: String,
+        offset: u16,
+        cpu: String,
+        os: String,
+        motherboard: String,
+    },
+    Status {
+        profile: PowerProfile,
+        temps: [u32; 2],
+        fans: [u32; 2],
+    },
+    Panic {
+        error: String,
+    },
 }
 
 #[derive(Debug, Clone, Encode, Decode)]

--- a/telemetry_server/src/main.rs
+++ b/telemetry_server/src/main.rs
@@ -1,7 +1,7 @@
 use bincode::config::standard;
-use ipc::{TelemetryData, TelemetryPayload, TelemetryDataV1, TelemetryPayloadV1};
+use ipc::{TelemetryData, TelemetryDataV1, TelemetryPayload, TelemetryPayloadV1};
 use log::{error, info, warn};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 use simplelog::SimpleLogger;
 use std::{
     sync::{Arc, Mutex},
@@ -13,7 +13,8 @@ static SERVER_ADDR: &str = "127.0.0.1:8368";
 const MAX_BODY_SIZE: usize = 512 * 1024;
 
 fn main() {
-    SimpleLogger::init(log::LevelFilter::Info, simplelog::Config::default()).expect("Failed to initialize logger");
+    SimpleLogger::init(log::LevelFilter::Info, simplelog::Config::default())
+        .expect("Failed to initialize logger");
 
     let conn = Connection::open("telemetry.db").expect("Failed to open DB");
     conn.execute_batch("PRAGMA journal_mode = WAL;").unwrap();
@@ -28,7 +29,8 @@ fn main() {
             raw_data BLOB NOT NULL
         )",
         [],
-    ).expect("Failed to create raw table");
+    )
+    .expect("Failed to create raw table");
 
     conn.execute(
         "CREATE TABLE IF NOT EXISTS startup_events (
@@ -44,13 +46,11 @@ fn main() {
             FOREIGN KEY(raw_id) REFERENCES raw_telemetry(id)
         )",
         [],
-    ).expect("Failed to create startup_events table");
+    )
+    .expect("Failed to create startup_events table");
 
     // TODO: remove later
-    let _ = conn.execute(
-        "ALTER TABLE startup_events ADD COLUMN motherboard TEXT",
-        [],
-    );
+    let _ = conn.execute("ALTER TABLE startup_events ADD COLUMN motherboard TEXT", []);
 
     conn.execute(
         "CREATE TABLE IF NOT EXISTS status_events (
@@ -66,7 +66,8 @@ fn main() {
             FOREIGN KEY(raw_id) REFERENCES raw_telemetry(id)
         )",
         [],
-    ).expect("Failed to create status_events table");
+    )
+    .expect("Failed to create status_events table");
 
     conn.execute(
         "CREATE TABLE IF NOT EXISTS panic_events (
@@ -78,7 +79,8 @@ fn main() {
             FOREIGN KEY(raw_id) REFERENCES raw_telemetry(id)
         )",
         [],
-    ).expect("Failed to create panic_events table");
+    )
+    .expect("Failed to create panic_events table");
 
     let db = Arc::new(Mutex::new(conn));
 
@@ -98,7 +100,9 @@ fn main() {
                 return;
             }
 
-            let daemon_version = request.headers().iter()
+            let daemon_version = request
+                .headers()
+                .iter()
                 .find(|h| h.field.equiv("X-Daemon-Version"))
                 .map(|h| h.value.as_str().to_string())
                 .unwrap_or_else(|| "Unknown".to_string());
@@ -110,7 +114,8 @@ fn main() {
             }
 
             let mut buffer = Vec::with_capacity(content_length.min(MAX_BODY_SIZE));
-            if request.as_reader().read_to_end(&mut buffer).is_err() || buffer.len() > MAX_BODY_SIZE {
+            if request.as_reader().read_to_end(&mut buffer).is_err() || buffer.len() > MAX_BODY_SIZE
+            {
                 warn!("Failed to read request body");
                 let _ = request.respond(Response::empty(400));
                 return;
@@ -129,8 +134,7 @@ fn main() {
             }
 
             let raw_id = lock.last_insert_rowid();
-            let config = standard()
-                .with_limit::<{ 64 * 1024 }>();
+            let config = standard().with_limit::<{ 64 * 1024 }>();
 
             // Try to deserialize as V2 (new format with motherboard)
             match bincode::decode_from_slice::<TelemetryPayload, _>(&buffer, config) {
@@ -160,7 +164,10 @@ fn main() {
                     };
 
                     if let Err(e) = insert_result {
-                        error!("Failed to insert parsed telemetry V2 (Raw ID: {}): {}", raw_id, e);
+                        error!(
+                            "Failed to insert parsed telemetry V2 (Raw ID: {}): {}",
+                            raw_id, e
+                        );
                         let _ = request.respond(Response::empty(500));
                     } else {
                         let _ = request.respond(Response::empty(201));
@@ -195,7 +202,10 @@ fn main() {
                             };
 
                             if let Err(e) = insert_result {
-                                error!("Failed to insert parsed telemetry V1 (Raw ID: {}): {}", raw_id, e);
+                                error!(
+                                    "Failed to insert parsed telemetry V1 (Raw ID: {}): {}",
+                                    raw_id, e
+                                );
                                 let _ = request.respond(Response::empty(500));
                             } else {
                                 let _ = request.respond(Response::empty(201));
@@ -203,7 +213,10 @@ fn main() {
                         }
                         Err(e) => {
                             // Both V1 and V2 deserialization failed, but raw data is securely stored
-                            warn!("Deserialization failed for both V1 and V2. Raw ID: {}, Error: {}", raw_id, e);
+                            warn!(
+                                "Deserialization failed for both V1 and V2. Raw ID: {}, Error: {}",
+                                raw_id, e
+                            );
                             let _ = request.respond(Response::empty(202));
                         }
                     }


### PR DESCRIPTION
## Summary

Batches the EC I/O path, fixes a real race in the battery-LED code, and adds two small protocol changes that cut IPC round-trips on the hot paths.

## What changed

### Bug fix
- `ec::hw::led::apply_battery_leds`: the read-modify-write of the `GPDRA` port was split across two separate `with_batch` calls. Another thread that touched the same port between the read and the write would have its bits silently dropped. Wrapped in a single `with_batch` so the read, the mask flip, and the write all happen under one lock.

### Performance
- `ec::hw::flexicharger::read_charge_limit` — read min and max in a single batch (2 lock cycles → 1, 16 syscalls → 8).
- `ec::hw::kbd_backlight::read_keyboard_backlight` — combine the kbd level byte and the custom-value byte in one batch (relevant when the level is `0xFF`).
- `ec::hw::getters` — new `read_status_snapshot()` that reads power profile + 2 temps + 4 fan RPM bytes in a single lock cycle.
- `telemetry::worker_loop` — uses `read_status_snapshot` instead of 3 sequential `with_batch` calls (3 lock cycles → 1 every 5 min).
- `telemetry::worker_loop` — when telemetry is disabled, the loop sleeps 30 min between wakeups instead of 5 min. Reduces spurious wakeups / power draw on laptops where the user has opted out.

### IPC protocol additions (additive, backward compatible)
- New `IpcRequest::GetMonitoring` and `IpcResponse::Monitoring(cpu_temp, sys_temp, cpu_rpm, gpu_rpm)`. Used by `lecoo-ctrl monitoring` which was issuing 2 sequential requests per tick (one for temps, one for RPMs).
- New `FanIndex::Both` variant. `lecoo-ctrl fan both <mode> [val]` now sends a single `SetFanMode` request instead of two (one for CPU, one for GPU). `apply_fan_mode` handles `Both` by writing both policies and both duties in a single batch.

Both additions are backward compatible with existing daemons and clients: old daemons that receive `GetMonitoring` or `FanIndex::Both` decode them as `UnexpectedVariant` and close the connection — same as any other unknown variant. Old clients that don't know about the new variants can still be served by updated daemons.

### Misc
- `.gitignore` — exclude the loose root release binaries (`/lecoo-ec-daemon`, `/lecoo-ctrl`) that are used by `install.sh` but shouldn't be committed.
- Clippy cleanup across the workspace.

## Impact

| Path | Before | After |
| --- | --- | --- |
| `lecoo-ctrl monitoring` @ 1 Hz | 2 round-trips + 2 IPC + 3 EC lock cycles / s | 1 round-trip + 1 IPC + 1 EC lock cycle / s |
| `lecoo-ctrl fan both` | 2 round-trips + 2 EC lock cycles | 1 round-trip + 1 EC lock cycle |
| `lecoo-ctrl charge` (read) | 2 EC lock cycles, 16 syscalls | 1 EC lock cycle, 8 syscalls |
| `lecoo-ctrl kbd` (Custom case) | 2 EC lock cycles | 1 EC lock cycle |
| Telemetry status poll (every 5 min) | 3 EC lock cycles | 1 EC lock cycle |
| Battery LED updates (charger events) | Lost-update race window | Atomic RMW |
| Wakeups/hour (telemetry disabled) | 12 | 2 |

## Verification

Tested on a **Lecoo Pro 14 N155A** (IT5571-07, HRAM offset 0x0400):

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo run -p lecoo-ctrl -- info` reports `Controller: IT5571 (Rev 07)`
- `temps`, `fans`, `charge`, `kbd`, `power`, `fan both`, `monitoring` all round-trip correctly
- `daemon settings read` returns the populated `CurrentSettings`
- Charger connect/disconnect events trigger the LED updates with the fix in place

## Notes

- The `Both` fan index uses a discriminant of `0xFF`. This was already a special value in the EC register namespace (the keyboard backlight uses it for "Custom" mode), but `FanIndex` is only ever used as a tag in IPC, never written to RAM as an offset, so the value is safe.
- Telemetry's adaptive interval does not change the *send* path: the user can re-enable telemetry at any time and the next status poll fires within at most 30 min (or whatever time was left in the previous `recv_timeout`).
- No changes to the on-disk state file format. Existing `daemon_state.bin` files decode unchanged.