### PR TITLE
Add N161A keyboard backlight support

### DIFF
--- a/daemon/src/ec/hw/kbd_backlight.rs
+++ b/daemon/src/ec/hw/kbd_backlight.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use super::EcDevice;
 
 pub fn read_keyboard_backlight(ec: &EcDevice) -> Result<KeyboardBacklightLevel> {
-    if ec.offsets.kbd_backlight_pwm {
+    if ec.offsets.kbd_backlight_pwm { // todo: improve this
         return match ec.read_reg(ec.offsets.reg_kbd_backlight)? {
             0x00 => Ok(KeyboardBacklightLevel::Off),
             0x4C => Ok(KeyboardBacklightLevel::Low),
@@ -30,7 +30,7 @@ pub fn read_keyboard_backlight(ec: &EcDevice) -> Result<KeyboardBacklightLevel> 
 pub fn apply_keyboard_backlight(ec: &EcDevice, level: &KeyboardBacklightLevel) -> Result<()> {
     let addr = ec.offsets.reg_kbd_backlight;
 
-    if ec.offsets.kbd_backlight_pwm {
+    if ec.offsets.kbd_backlight_pwm { // todo: improve this
         let value = match level {
             KeyboardBacklightLevel::Off => 0x00,
             KeyboardBacklightLevel::Low => 0x4C,

--- a/daemon/src/ec/hw/kbd_backlight.rs
+++ b/daemon/src/ec/hw/kbd_backlight.rs
@@ -3,6 +3,16 @@ use anyhow::Result;
 use super::EcDevice;
 
 pub fn read_keyboard_backlight(ec: &EcDevice) -> Result<KeyboardBacklightLevel> {
+    if ec.offsets.kbd_backlight_pwm {
+        return match ec.read_reg(ec.offsets.reg_kbd_backlight)? {
+            0x00 => Ok(KeyboardBacklightLevel::Off),
+            0x4C => Ok(KeyboardBacklightLevel::Low),
+            0x99 => Ok(KeyboardBacklightLevel::Medium),
+            0xFF => Ok(KeyboardBacklightLevel::High),
+            v => Ok(KeyboardBacklightLevel::Custom(v)),
+        };
+    }
+
     match ec.read_reg(ec.offsets.reg_kbd_backlight)? {
         0x00 => Ok(KeyboardBacklightLevel::Off),
         0x01 => Ok(KeyboardBacklightLevel::Low),
@@ -19,6 +29,18 @@ pub fn read_keyboard_backlight(ec: &EcDevice) -> Result<KeyboardBacklightLevel> 
 
 pub fn apply_keyboard_backlight(ec: &EcDevice, level: &KeyboardBacklightLevel) -> Result<()> {
     let addr = ec.offsets.reg_kbd_backlight;
+
+    if ec.offsets.kbd_backlight_pwm {
+        let value = match level {
+            KeyboardBacklightLevel::Off => 0x00,
+            KeyboardBacklightLevel::Low => 0x4C,
+            KeyboardBacklightLevel::Medium => 0x99,
+            KeyboardBacklightLevel::High => 0xFF,
+            KeyboardBacklightLevel::Custom(v) => *v,
+        };
+        ec.write_reg(addr, value)?;
+        return Ok(());
+    }
 
     match level {
         KeyboardBacklightLevel::Off => ec.write_reg(addr, 0x00)?,

--- a/daemon/src/ec/mod.rs
+++ b/daemon/src/ec/mod.rs
@@ -47,6 +47,10 @@ impl EcDevice {
         else if motherboard.contains("N155D") {
             log::info!("Detected motherboard N155D.");
             offsets = EcOffsets::DEFAULT_N155D;
+        }
+        else if motherboard.contains("N161A") {
+            log::info!("Detected motherboard N161A.");
+            offsets = EcOffsets::DEFAULT_N161A;
         } else if !insecure_mode {
             // bail!("Unsupported motherboard: {}", motherboard);
             log::error!("Unsupported motherboard: {}", motherboard);

--- a/daemon/src/ec/offsets.rs
+++ b/daemon/src/ec/offsets.rs
@@ -47,6 +47,7 @@ pub struct EcOffsets {
     // Keyboard Backlight
     pub reg_kbd_backlight: u16,
     pub reg_kbd_custom_val: u16,
+    pub kbd_backlight_pwm: bool,
 
     // == LED Controller (Port A0 / PWM Engine) ==
 
@@ -113,6 +114,7 @@ impl EcOffsets {
         // Absolute Regs (Keyboard)
         reg_kbd_backlight: 0x0F05,
         reg_kbd_custom_val: 0x1806,
+        kbd_backlight_pwm: false,
 
         // Absolute Regs (LED)
         reg_gpdra: 0x1601,
@@ -134,6 +136,15 @@ impl EcOffsets {
     pub const DEFAULT_N155D: Self = Self {
         ram_led_bypass: 0x4F, // or 0x50, 0x51, 0x54
         // The rest of the offsets remain the same as the default configuration
+        ..Self::DEFAULT_N155A
+    };
+
+    pub const DEFAULT_N161A: Self = Self {
+        // N161A keyboard backlight uses a direct PWM duty register:
+        // 0x00 = Off, 0x4C = Low, 0x99 = Medium, 0xFF = High.
+        reg_kbd_backlight: 0x1803,
+        reg_kbd_custom_val: 0x1803,
+        kbd_backlight_pwm: true,
         ..Self::DEFAULT_N155A
     };
 }


### PR DESCRIPTION
## Summary

This PR adds keyboard backlight support for the Lecoo N161A while preserving the existing keyboard backlight behaviour for supported N155 models.

## Hardware

- Model: Lecoo N161A
- EC controller: IT5570
- Chip ID: `0x55 0x70`
- Revision: `0x02`
- Super I/O index port: `0x4E`
- Super I/O data port: `0x4F`
- HRAM base: `0x0400`

## N161A keyboard backlight mapping

The N161A uses EC register `0x1803`:

| Level | Value |
|---|---:|
| Off | `0x00` |
| Low | `0x4C` |
| Medium | `0x99` |
| High | `0xFF` |

The existing `0x0F05` register remains at `0x00` and does not control keyboard backlight brightness on this model.

## Verification

I verified repeated and reversible writes to `0x1803`:

- each level changes the keyboard brightness immediately;
- repeated writes produce consistent results;
- returning to a previous value restores the corresponding brightness level.

## Scope

This PR only adds N161A keyboard backlight support.

Battery charge-limit and fan-control support are not included because their N161A register mappings and control sequences have not yet been fully verified.

## Testing

- [x] N161A keyboard backlight levels tested manually
- [x] Reversible writes tested
- [x] Existing N155 logic kept separate
- [x] Project builds successfully
- [x] Tested on N155 hardware