### PR TITLE
Add N161A native charge control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/dist/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This software is primarily developed and tested on the Lecoo Pro 14 (Lecoo N155)
 | Lecoo Pro 14 Amd (H255) | N155A | IT5571-07 | Confirmed Working |
 | Lecoo Pro 14 Intel (Core Ultra 5) | N155D | IT5570-02 | Working |
 | Lecoo Pro 14 Intel (i5-13420H) | N155C | IT5570? | Probably Working |
-| Lecoo Pro 16 / N161A | N161A | IT5570-02 | Keyboard Backlight Only |
+| Lecoo Pro 16 / N161A | N161A | IT5570-02 | Keyboard Backlight and experimental native charge control |
 
 **Note:** This software might theoretically work on other Emdoor-based laptops utilizing the ITE IT5570 or IT8987 Embedded Controllers, as the daemon includes basic HRAM offset auto-detection.
 
@@ -101,6 +101,18 @@ Here are the primary commands for `lecoo-ctrl`:
   * `lecoo-ctrl charge <full|high|balanced|lifespan|desk>` - Set battery charging thresholds (FlexiCharger).
       * *Example:* `lecoo-ctrl charge desk` (Limits charging to 40-50% for permanent AC usage).
       * Run `lecoo-ctrl charge` without arguments to view the current limit and battery capacity.
+      * LECOO N161A uses a separate native one-write hold mode instead of
+        FlexiCharger thresholds:
+        * `lecoo-ctrl charge hold` pauses charging at the current level while
+          RSOC is above 61% and below 85%. At 61% or below, use `native`.
+        * `lecoo-ctrl charge resume` restores the exact EC policy saved before
+          hold.
+        * `lecoo-ctrl charge native` experimentally arms the firmware-native
+          protection at or below 60% while the battery is actively charging.
+          The firmware then charges to approximately 75-76% and keeps the
+          battery near that level while AC remains connected.
+        * This mode performs no periodic EC writes and does not claim a
+          configurable start/stop percentage.
 
 ### Thermal Control
 

--- a/cli/locales/cn.yml
+++ b/cli/locales/cn.yml
@@ -63,6 +63,9 @@ arg_charge_limit_high_help: "高容量（95%）"
 arg_charge_limit_balanced_help: "平衡模式（80%）"
 arg_charge_limit_lifespan_help: "最大电池寿命（60%）"
 arg_charge_limit_desk_help: "桌面模式（40%）"
+arg_charge_limit_hold_help: "N161A：在当前电量暂停充电（须高于61%且低于85%）"
+arg_charge_limit_native_help: "N161A 实验功能：在不高于60%时启用，随后维持在约75-76%"
+arg_charge_limit_resume_help: "N161A：恢复正常充电"
 
 arg_charge_limit_long_help: |
   设置电池充电限制模式（FlexiCharger）。
@@ -90,6 +93,11 @@ resp_charge_title: "🔋 充电限制 (FlexiCharger):"
 resp_charge_full: "   模式: 全容量（充电至100%）"
 resp_charge_range: "   开始充电: %{min}%\n   停止充电:  %{max}%"
 resp_charge_current: "   当前电池电量: %{cur}%"
+resp_native_charge_title: "🔋 充电控制（LECOO N161A 原生策略）："
+resp_native_charge_unsupported: "   当前主板不支持原生暂停；仍可使用 FlexiCharger 档位。"
+resp_native_charge_normal: "   模式：正常充电"
+resp_native_charge_holding: "   模式：维持当前电量"
+resp_native_charge_protection: "   模式：原生电池保护（插电时维持在约75-76%）"
 resp_power_title: "⚡ 电源配置:"
 resp_power_current: "   当前: %{prof}"
 resp_telemetry_disabled: |

--- a/cli/locales/en.yml
+++ b/cli/locales/en.yml
@@ -63,6 +63,9 @@ arg_charge_limit_high_help: "High capacity (95%)"
 arg_charge_limit_balanced_help: "Balanced mode (80%)"
 arg_charge_limit_lifespan_help: "Maximum battery lifespan (60%)"
 arg_charge_limit_desk_help: "Desk mode (40%)"
+arg_charge_limit_hold_help: "N161A: pause charging at the current level (above 61% and below 85%)"
+arg_charge_limit_native_help: "N161A experimental: arm at or below 60%, then maintain approximately 75-76%"
+arg_charge_limit_resume_help: "N161A: restore normal charging"
 
 arg_charge_limit_long_help: |
   Set battery charge limit mode (FlexiCharger).
@@ -90,6 +93,11 @@ resp_charge_title: "🔋 Charge Limit (FlexiCharger):"
 resp_charge_full: "   Mode: Full Capacity (Charges to 100%)"
 resp_charge_range: "   Start charging at: %{min}%\n   Stop charging at:  %{max}%"
 resp_charge_current: "   Current Battery Charge: %{cur}%"
+resp_native_charge_title: "🔋 Charge Control (LECOO N161A Native Policy):"
+resp_native_charge_unsupported: "   Native hold is not supported on this motherboard. FlexiCharger profiles remain available."
+resp_native_charge_normal: "   Mode: Normal charging"
+resp_native_charge_holding: "   Mode: Holding at the current charge level"
+resp_native_charge_protection: "   Mode: Native battery protection (maintains approximately 75-76% on AC)"
 resp_power_title: "⚡ Power Profile:"
 resp_power_current: "   Current: %{prof}"
 resp_telemetry_disabled: |

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -196,6 +196,12 @@ enum CliChargeLimit {
     Lifespan,
     #[value(help = loc!("arg_charge_limit_desk_help"))]
     Desk,
+    #[value(help = loc!("arg_charge_limit_hold_help"))]
+    Hold,
+    #[value(help = loc!("arg_charge_limit_native_help"))]
+    Native,
+    #[value(help = loc!("arg_charge_limit_resume_help"))]
+    Resume,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -261,16 +267,24 @@ fn main() -> anyhow::Result<()> {
 
         Commands::Charge { limit } => match limit {
             Some(cli_limit) => {
-                let ipc_limit = match cli_limit {
-                    CliChargeLimit::Full => ChargeLimit::FullCapacity,
-                    CliChargeLimit::High => ChargeLimit::HighCapacity,
-                    CliChargeLimit::Balanced => ChargeLimit::Balanced,
-                    CliChargeLimit::Lifespan => ChargeLimit::MaximumLifespan,
-                    CliChargeLimit::Desk => ChargeLimit::DeskMode,
-                };
-                IpcRequest::SetChargeLimit(ipc_limit)
+                match cli_limit {
+                    CliChargeLimit::Hold => IpcRequest::EnableNativeChargeHold,
+                    CliChargeLimit::Native => IpcRequest::EnableNativeChargeProtection,
+                    CliChargeLimit::Resume => IpcRequest::ResumeNativeCharging,
+                    other => {
+                        let ipc_limit = match other {
+                            CliChargeLimit::Full => ChargeLimit::FullCapacity,
+                            CliChargeLimit::High => ChargeLimit::HighCapacity,
+                            CliChargeLimit::Balanced => ChargeLimit::Balanced,
+                            CliChargeLimit::Lifespan => ChargeLimit::MaximumLifespan,
+                            CliChargeLimit::Desk => ChargeLimit::DeskMode,
+                            CliChargeLimit::Hold | CliChargeLimit::Native | CliChargeLimit::Resume => unreachable!(),
+                        };
+                        IpcRequest::SetChargeLimit(ipc_limit)
+                    }
+                }
             }
-            None => IpcRequest::GetChargeLimit,
+            None => IpcRequest::GetNativeChargeHold,
         },
 
         Commands::Kbd { mode, val } => match mode {
@@ -342,6 +356,27 @@ fn main() -> anyhow::Result<()> {
                 println!("{}", t!("resp_charge_range", min = min, max = max));
             }
             println!("{}", t!("resp_charge_current", cur = cur));
+        }
+
+        IpcResponse::NativeChargeHold(status) => {
+            println!("{}", t!("resp_native_charge_title"));
+            match status {
+                ipc::NativeChargeHoldStatus::Unsupported => {
+                    println!("{}", t!("resp_native_charge_unsupported"));
+                }
+                ipc::NativeChargeHoldStatus::Normal { rsoc } => {
+                    println!("{}", t!("resp_native_charge_normal"));
+                    println!("{}", t!("resp_charge_current", cur = rsoc));
+                }
+                ipc::NativeChargeHoldStatus::Holding { rsoc } => {
+                    println!("{}", t!("resp_native_charge_holding"));
+                    println!("{}", t!("resp_charge_current", cur = rsoc));
+                }
+                ipc::NativeChargeHoldStatus::NativeProtection { rsoc } => {
+                    println!("{}", t!("resp_native_charge_protection"));
+                    println!("{}", t!("resp_charge_current", cur = rsoc));
+                }
+            }
         }
 
         IpcResponse::PowerLimit(prof) => {

--- a/daemon/src/ec/hw/mod.rs
+++ b/daemon/src/ec/hw/mod.rs
@@ -6,6 +6,7 @@ mod kbd_backlight;
 mod led;
 mod fan;
 mod flexicharger;
+mod n161a_charge_hold;
 
 pub use power_profile::*;
 pub use getters::*;
@@ -13,3 +14,4 @@ pub use kbd_backlight::*;
 pub use led::*;
 pub use fan::*;
 pub use flexicharger::*;
+pub use n161a_charge_hold::*;

--- a/daemon/src/ec/hw/n161a_charge_hold.rs
+++ b/daemon/src/ec/hw/n161a_charge_hold.rs
@@ -1,0 +1,363 @@
+use anyhow::{Context, Result, bail};
+use ipc::NativeChargeHoldStatus;
+
+use super::EcDevice;
+
+const POLICY_ADDR: u16 = 0x0414;
+const RSOC_ADDR: u16 = 0x050F;
+const CURRENT_TARGET_ADDR: u16 = 0x05D4;
+const CURRENT_READBACK_ADDR: u16 = 0x05E4;
+const NATIVE_MODE_MASK: u8 = 0x13;
+const PRELATCHED_MODE_MASK: u8 = 0x17;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SavedMode {
+    Hold,
+    Native,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SavedState {
+    original: u8,
+    mode: SavedMode,
+}
+
+#[cfg(windows)]
+const HOLD_STATE_PATH: &str = "C:\\ProgramData\\LecooControl\\n161a_charge_hold_state";
+#[cfg(not(windows))]
+const HOLD_STATE_PATH: &str = "/var/lib/lecoo-control/n161a_charge_hold_state";
+
+fn require_n161a(ec: &EcDevice) -> Result<()> {
+    if !ec.offsets.n161a_native_charge_hold {
+        bail!("native charge hold is supported only on the LECOO N161A");
+    }
+    Ok(())
+}
+
+fn save_original_policy(value: u8, mode: SavedMode) -> Result<()> {
+    let path = std::path::Path::new(HOLD_STATE_PATH);
+    let parent = path
+        .parent()
+        .context("invalid native charge-hold state path")?;
+    std::fs::create_dir_all(parent)?;
+    let mode = match mode {
+        SavedMode::Hold => "hold",
+        SavedMode::Native => "native",
+    };
+    std::fs::write(
+        path,
+        format!("version=1\noriginal={value:02X}\nmode={mode}\n"),
+    )?;
+    Ok(())
+}
+
+fn load_saved_state() -> Result<SavedState> {
+    let value = std::fs::read_to_string(HOLD_STATE_PATH)
+        .context("native charge-hold restore state was not found")?;
+    let trimmed = value.trim();
+
+    // Backward compatibility with the first test build's single hex byte.
+    if let Ok(original) = u8::from_str_radix(trimmed, 16) {
+        return Ok(SavedState {
+            original,
+            mode: SavedMode::Hold,
+        });
+    }
+
+    let mut original = None;
+    let mut mode = None;
+    for line in trimmed.lines() {
+        if let Some(value) = line.strip_prefix("original=") {
+            original = Some(
+                u8::from_str_radix(value, 16)
+                    .context("native charge state has an invalid original policy")?,
+            );
+        } else if let Some(value) = line.strip_prefix("mode=") {
+            mode = Some(match value {
+                "hold" => SavedMode::Hold,
+                "native" => SavedMode::Native,
+                _ => bail!("native charge state has an unknown mode"),
+            });
+        }
+    }
+    Ok(SavedState {
+        original: original.context("native charge state has no original policy")?,
+        mode: mode.context("native charge state has no mode")?,
+    })
+}
+
+fn hold_target(original: u8, rsoc: u8) -> Result<u8> {
+    if rsoc <= 61 {
+        bail!(
+            "N161A charge hold requires charge above 61% and below 85% (current: {rsoc}%); at 61% or below use `lecoo-ctrl charge native`"
+        );
+    }
+    if rsoc >= 85 {
+        bail!(
+            "N161A charge hold requires charge above 61% and below 85% (current: {rsoc}%); wait until charge falls below 85%"
+        );
+    }
+    let mask = if rsoc <= 75 {
+        PRELATCHED_MODE_MASK
+    } else {
+        NATIVE_MODE_MASK
+    };
+    Ok(original | mask)
+}
+
+fn read_word_is_zero(b: &crate::ec::EcBatch<'_>, addr: u16) -> Result<bool> {
+    Ok(b.read_reg(addr)? == 0 && b.read_reg(addr + 1)? == 0)
+}
+
+fn wait_for_hold_confirmation(ec: &EcDevice, expected_policy: u8) -> Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let confirmed = ec.with_batch(|b| {
+            let policy = b.read_reg(POLICY_ADDR)?;
+            let target_zero = read_word_is_zero(b, CURRENT_TARGET_ADDR)?;
+            let readback_zero = read_word_is_zero(b, CURRENT_READBACK_ADDR)?;
+            Ok(
+                (policy == expected_policy || policy & NATIVE_MODE_MASK == NATIVE_MODE_MASK)
+                    && target_zero
+                    && readback_zero,
+            )
+        })?;
+        if confirmed {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "N161A charge hold was written but not confirmed within 15 seconds; do not repeat it automatically, use `lecoo-ctrl charge resume`"
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+}
+
+fn wait_for_native_arm_confirmation(ec: &EcDevice) -> Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let confirmed = ec.with_batch(|b| {
+            let policy = b.read_reg(POLICY_ADDR)?;
+            let target_active = !read_word_is_zero(b, CURRENT_TARGET_ADDR)?;
+            let readback_active = !read_word_is_zero(b, CURRENT_READBACK_ADDR)?;
+            Ok(policy & NATIVE_MODE_MASK == NATIVE_MODE_MASK && target_active && readback_active)
+        })?;
+        if confirmed {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "N161A native protection was written but active charging was not confirmed within 15 seconds; do not repeat automatically, use `lecoo-ctrl charge resume`"
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+}
+
+pub fn read_native_charge_hold(ec: &EcDevice) -> Result<NativeChargeHoldStatus> {
+    if !ec.offsets.n161a_native_charge_hold {
+        return Ok(NativeChargeHoldStatus::Unsupported);
+    }
+
+    ec.with_batch(|b| {
+        let rsoc = b.read_reg(RSOC_ADDR)?;
+        let policy = b.read_reg(POLICY_ADDR)?;
+        if policy & NATIVE_MODE_MASK == NATIVE_MODE_MASK {
+            let mode = load_saved_state().ok().map(|state| state.mode);
+            if mode == Some(SavedMode::Native) {
+                Ok(NativeChargeHoldStatus::NativeProtection { rsoc })
+            } else {
+                Ok(NativeChargeHoldStatus::Holding { rsoc })
+            }
+        } else {
+            Ok(NativeChargeHoldStatus::Normal { rsoc })
+        }
+    })
+}
+
+pub fn enable_native_charge_hold(ec: &EcDevice) -> Result<()> {
+    require_n161a(ec)?;
+
+    let (rsoc, original, target_zero, readback_zero) = ec.with_batch(|b| {
+        let rsoc = b.read_reg(RSOC_ADDR)?;
+        let original = b.read_reg(POLICY_ADDR)?;
+        let target_zero = read_word_is_zero(b, CURRENT_TARGET_ADDR)?;
+        let readback_zero = read_word_is_zero(b, CURRENT_READBACK_ADDR)?;
+        Ok((rsoc, original, target_zero, readback_zero))
+    })?;
+
+    // Range validation must precede the idempotent-policy check. Below the
+    // native release boundary the root bits can remain set after the actual
+    // current-zero latch has already been cleared by firmware.
+    let target = hold_target(original, rsoc)?;
+
+    if original & NATIVE_MODE_MASK == NATIVE_MODE_MASK {
+        // We may only treat this as our own idempotent request when the exact
+        // restore byte is still available. Never adopt an unknown native mode.
+        let saved = load_saved_state().context(
+            "native charge hold is active, but no valid restore state exists; refusing to adopt it",
+        )?;
+        if saved.mode != SavedMode::Hold {
+            bail!(
+                "N161A native protection is already active; run `lecoo-ctrl charge resume` before switching to hold"
+            );
+        }
+        if target_zero && readback_zero {
+            log::info!(
+                "N161A native charge hold is already active at {}%; no EC write was needed",
+                rsoc
+            );
+            return Ok(());
+        }
+        if target_zero || readback_zero {
+            bail!(
+                "N161A charge-current target and readback disagree; wait and query status before retrying"
+            );
+        }
+
+        // Firmware can keep the root mode after releasing bit2 below 60%.
+        // A valid-range hold request may re-establish that one latch without
+        // discarding the original restore byte.
+        let rearmed = original | PRELATCHED_MODE_MASK;
+        ec.write_reg(POLICY_ADDR, rearmed)?;
+        wait_for_hold_confirmation(ec, rearmed)?;
+        log::info!(
+            "Re-armed N161A native charge hold at {}%: 0x{:02X} -> 0x{:02X}",
+            rsoc,
+            original,
+            rearmed
+        );
+        return Ok(());
+    }
+    if original & 0x02 != 0 {
+        bail!(
+            "N161A policy bit1 is already set in an unrecognized state (policy 0x{original:02X})"
+        );
+    }
+    if target_zero || readback_zero {
+        bail!(
+            "N161A charge hold requires active charging current; connect AC power and wait for charging to begin"
+        );
+    }
+
+    // Persist the exact restore byte before the single EC write.
+    save_original_policy(original, SavedMode::Hold)?;
+    ec.write_reg(POLICY_ADDR, target)?;
+    wait_for_hold_confirmation(ec, target)?;
+    log::info!(
+        "Enabled N161A native charge hold at {}%: 0x{:02X} -> 0x{:02X}",
+        rsoc,
+        original,
+        target
+    );
+    Ok(())
+}
+
+pub fn enable_native_charge_protection(ec: &EcDevice) -> Result<()> {
+    require_n161a(ec)?;
+
+    let (rsoc, original, target_zero, readback_zero) = ec.with_batch(|b| {
+        Ok((
+            b.read_reg(RSOC_ADDR)?,
+            b.read_reg(POLICY_ADDR)?,
+            read_word_is_zero(b, CURRENT_TARGET_ADDR)?,
+            read_word_is_zero(b, CURRENT_READBACK_ADDR)?,
+        ))
+    })?;
+
+    if original & NATIVE_MODE_MASK == NATIVE_MODE_MASK {
+        let saved = load_saved_state().context(
+            "native charge policy is active, but no valid restore state exists; refusing to adopt it",
+        )?;
+        if saved.mode == SavedMode::Native {
+            log::info!(
+                "N161A native charge protection is already armed at {}%; no EC write was needed",
+                rsoc
+            );
+            return Ok(());
+        }
+        bail!(
+            "N161A charge hold is already active; run `lecoo-ctrl charge resume` before switching to native protection"
+        );
+    }
+    if original & 0x02 != 0 {
+        bail!(
+            "N161A policy bit1 is already set in an unrecognized state (policy 0x{original:02X})"
+        );
+    }
+    if rsoc > 60 {
+        bail!(
+            "experimental N161A native protection must initially be armed at or below 60% (current: {rsoc}%)"
+        );
+    }
+    if target_zero || readback_zero {
+        bail!(
+            "N161A native protection requires active charging current; connect AC power and wait for charging to begin"
+        );
+    }
+
+    let target = original | NATIVE_MODE_MASK;
+    save_original_policy(original, SavedMode::Native)?;
+    ec.write_reg(POLICY_ADDR, target)?;
+
+    wait_for_native_arm_confirmation(ec)?;
+
+    log::info!(
+        "Armed N161A native charge protection at {}%: 0x{:02X} -> 0x{:02X}",
+        rsoc,
+        original,
+        target
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_outside_confirmed_range() {
+        assert!(hold_target(0x05, 61).is_err());
+        assert!(hold_target(0x05, 85).is_err());
+    }
+
+    #[test]
+    fn prelatches_lower_band() {
+        assert_eq!(hold_target(0x01, 62).unwrap(), 0x17);
+        assert_eq!(hold_target(0x01, 75).unwrap(), 0x17);
+    }
+
+    #[test]
+    fn uses_native_entry_in_upper_band() {
+        assert_eq!(hold_target(0x01, 76).unwrap(), 0x13);
+        assert_eq!(hold_target(0x01, 84).unwrap(), 0x13);
+    }
+}
+
+pub fn resume_native_charging(ec: &EcDevice) -> Result<()> {
+    require_n161a(ec)?;
+    let current = ec.read_reg(POLICY_ADDR)?;
+    if current & NATIVE_MODE_MASK != NATIVE_MODE_MASK {
+        // The EC releases this latch itself below the native lower boundary.
+        // In that case resume is an idempotent cleanup operation, not a write.
+        if std::path::Path::new(HOLD_STATE_PATH).exists() {
+            std::fs::remove_file(HOLD_STATE_PATH)?;
+        }
+        log::info!(
+            "N161A native charge hold is already inactive (policy 0x{:02X}); no EC write was needed",
+            current
+        );
+        return Ok(());
+    }
+
+    let saved = load_saved_state()?;
+    ec.write_reg(POLICY_ADDR, saved.original)?;
+    std::fs::remove_file(HOLD_STATE_PATH)?;
+    log::info!(
+        "Restored N161A charge policy exactly: 0x{:02X} -> 0x{:02X}",
+        current,
+        saved.original
+    );
+    Ok(())
+}

--- a/daemon/src/ec/offsets.rs
+++ b/daemon/src/ec/offsets.rs
@@ -34,6 +34,9 @@ pub struct EcOffsets {
     pub ram_bat_limit_min: u16,
     pub ram_bat_limit_max: u16,
 
+    /// N161A fixed native charge-policy state machine at absolute EC 0x0414.
+    pub n161a_native_charge_hold: bool,
+
     /// LED state override (0x00 = Auto, 0x01 = Custom/Bypass)
     pub ram_led_bypass: u16,
 
@@ -106,6 +109,7 @@ impl EcOffsets {
         ram_bat_rsoc: 0x93,
         ram_bat_limit_min: 0xBC,
         ram_bat_limit_max: 0xBB,
+        n161a_native_charge_hold: false,
 
         // Bypasses
         ram_led_bypass: 0x55,
@@ -145,6 +149,7 @@ impl EcOffsets {
         reg_kbd_backlight: 0x1803,
         reg_kbd_custom_val: 0x1803,
         kbd_backlight_pwm: true,
+        n161a_native_charge_hold: true,
         ..Self::DEFAULT_N155A
     };
 }

--- a/daemon/src/handlers.rs
+++ b/daemon/src/handlers.rs
@@ -64,6 +64,7 @@ pub fn do_work(req: &IpcRequest) -> IpcResponse {
         IpcRequest::GetTemperatures => get_temperatures(ec),
 
         IpcRequest::GetChargeLimit => get_charge_limit(ec),
+        IpcRequest::GetNativeChargeHold => get_native_charge_hold(ec),
 
         IpcRequest::GetPowerProfile => get_power_profile(ec),
 
@@ -77,6 +78,9 @@ pub fn do_work(req: &IpcRequest) -> IpcResponse {
         IpcRequest::SetKeyboardBacklight(level) => set_keyboard_backlight(ec, level),
 
         IpcRequest::SetChargeLimit(limit) => set_charge_limit(ec, limit),
+        IpcRequest::EnableNativeChargeHold => enable_native_charge_hold(ec),
+        IpcRequest::EnableNativeChargeProtection => enable_native_charge_protection(ec),
+        IpcRequest::ResumeNativeCharging => resume_native_charging(ec),
 
         IpcRequest::SetLedMode(mode) => set_led_mode(ec, mode),
 
@@ -135,6 +139,14 @@ fn get_charge_limit(ec: &EcDevice) -> Result<IpcResponse> {
     Ok(IpcResponse::ChargeLimit(min, max, current))
 }
 
+fn get_native_charge_hold(ec: &EcDevice) -> Result<IpcResponse> {
+    let status = ec::read_native_charge_hold(ec)?;
+    if status == ipc::NativeChargeHoldStatus::Unsupported {
+        return get_charge_limit(ec);
+    }
+    Ok(IpcResponse::NativeChargeHold(status))
+}
+
 fn get_power_profile(ec: &EcDevice) -> Result<IpcResponse> {
     let profile = ec::read_power_profile(ec)?;
     Ok(IpcResponse::PowerLimit(profile))
@@ -176,10 +188,30 @@ pub fn get_state() -> Result<std::sync::MutexGuard<'static, CurrentSettings>> {
 }
 
 fn set_charge_limit(ec: &EcDevice, profile: &ChargeLimit) -> Result<IpcResponse> {
+    if ec.offsets.n161a_native_charge_hold {
+        return Err(anyhow!(
+            "FlexiCharger threshold profiles are not supported on N161A; use `lecoo-ctrl charge hold` or `lecoo-ctrl charge resume`"
+        ));
+    }
     ec::apply_charge_limit(ec, &profile)?;
     let mut state = get_state()?;
     state.charge_limit = *profile;
 
+    Ok(IpcResponse::Success)
+}
+
+fn enable_native_charge_hold(ec: &EcDevice) -> Result<IpcResponse> {
+    ec::enable_native_charge_hold(ec)?;
+    Ok(IpcResponse::Success)
+}
+
+fn enable_native_charge_protection(ec: &EcDevice) -> Result<IpcResponse> {
+    ec::enable_native_charge_protection(ec)?;
+    Ok(IpcResponse::Success)
+}
+
+fn resume_native_charging(ec: &EcDevice) -> Result<IpcResponse> {
+    ec::resume_native_charging(ec)?;
     Ok(IpcResponse::Success)
 }
 

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -30,6 +30,9 @@ pub enum IpcRequest {
     /// Get the current battery charge limit
     GetChargeLimit,
 
+    /// Get N161A native one-write charge-hold status.
+    GetNativeChargeHold,
+
     /// Get the current power profile
     GetPowerProfile,
 
@@ -50,6 +53,15 @@ pub enum IpcRequest {
 
     /// Set battery charge threshold
     SetChargeLimit(ChargeLimit),
+
+    /// Pause charging at the current RSOC on a supported N161A.
+    EnableNativeChargeHold,
+
+    /// Arm the N161A firmware's native protection at or below 60%.
+    EnableNativeChargeProtection,
+
+    /// Restore the exact EC policy byte saved before native hold.
+    ResumeNativeCharging,
 
     /// Control the LED Ring
     SetLedMode(PowerLedMode),
@@ -76,6 +88,9 @@ pub enum IpcResponse {
 
     /// Current battery charge limit (min/max percentages)
     ChargeLimit(u8, u8, u8),
+
+    /// N161A native one-write charge-hold status.
+    NativeChargeHold(NativeChargeHoldStatus),
 
     /// Current keyboard backlight brightness
     KeyboardBacklight(KeyboardBacklightLevel),

--- a/ipc/src/structs.rs
+++ b/ipc/src/structs.rs
@@ -117,6 +117,15 @@ impl ChargeLimit {
     }
 }
 
+/// N161A-specific, one-write native charge-hold status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+pub enum NativeChargeHoldStatus {
+    Unsupported,
+    Normal { rsoc: u8 },
+    Holding { rsoc: u8 },
+    NativeProtection { rsoc: u8 },
+}
+
 /// Represents the LED Ring behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum PowerLedMode {


### PR DESCRIPTION
## Summary

This PR adds N161A-specific native battery charge control without changing
the existing FlexiCharger implementation for other supported models.

It introduces three commands:

- `lecoo-ctrl charge native`
- `lecoo-ctrl charge hold`
- `lecoo-ctrl charge resume`

Related to #14.

## Why this uses a separate implementation

The existing FlexiCharger minimum/maximum threshold registers do not appear
to be authoritative on the N161A.

Firmware tracing and hardware testing instead identified a native charging
policy at absolute EC address `0x0414`. Because its behavior differs from the
configurable FlexiCharger profiles, this PR exposes it as an N161A-specific
backend rather than mapping it to `desk`, `lifespan`, or the other existing
profiles.

## Observed behavior

### Native protection

`lecoo-ctrl charge native` can initially be armed while:

- the detected motherboard is N161A;
- RSOC is at or below 60%;
- AC is connected and charge current is active.

It performs one guarded policy write. The firmware subsequently charges the
battery to approximately 75–76% and keeps it near that level while AC remains
connected. It does not intentionally discharge the battery back to 60%.

I have used this mode on the N161A for two days without periodic daemon writes.

### Hold current charge level

`lecoo-ctrl charge hold` pauses charging in the confirmed 61–84% range:

- RSOC 61–75% uses the pre-latched policy entry;
- RSOC 76–84% uses the native policy entry.

After confirmation, charge-current target and readback both reach zero, keeping
the battery close to its current percentage while AC remains connected.

### Resume

`lecoo-ctrl charge resume` restores the exact `0x0414` value saved before
enabling native protection or hold.

## Safety measures

- Restricted to detected N161A hardware.
- Requires active charging current before the initial write.
- Rejects unconfirmed RSOC ranges.
- Saves the exact original policy byte before writing.
- Uses a single EC write followed by read-only confirmation.
- Does not repeatedly write EC registers.
- Refuses to adopt an unknown pre-existing policy state.
- Supports idempotent hold, native, and resume handling.
- Existing FlexiCharger behavior remains unchanged on other models.
- FlexiCharger profiles are rejected on N161A instead of reporting false
  success.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- Three N161A policy-boundary unit tests pass.
- Hardware-tested on a Lecoo N161A with an IT5570-02 EC.
- Native protection has been used continuously for two days.
- Hold behavior was tested in both the 61–75% and 76–84% entry ranges.
- Resume restores normal charging.